### PR TITLE
feat: add type_text tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `type_text` tool that types text key by key into the focused element, with an optional key to press afterwards
+
 ## [0.10.1] - 2026-08-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ descriptions and parameters (generated from the source).
 
 - Pages: list/new/navigate/select/close/get_page_text (get_page_text supports optional `saveTo`)
 - Snapshot/UID: take/resolve/clear (take supports optional `saveTo`)
-- Input: click/hover/fill/drag/upload/form fill
+- Input: click/hover/fill/drag/upload/form fill/press_key/type_text
 - Network: list/get (ID‑first, filters, always‑on capture; both support optional `saveTo`)
 - Downloads: list_downloads/clear_downloads (always‑on capture), set_download_behavior (allow/deny/default)
 - Console: list/clear (list supports optional `saveTo`)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -2,7 +2,7 @@
 
 # Tool reference
 
-The server exposes 53 tools grouped into 16 modules. Which modules are
+The server exposes 54 tools grouped into 16 modules. Which modules are
 enabled depends on `--tool-preset` or `--tools`; see
 [Tool modules and presets](../README.md#tool-modules-and-presets) in the README.
 
@@ -15,7 +15,7 @@ Mozilla-internal build and `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1`; the public packag
 | ------------------------- | ----- | ---- | ----- | --------- | ------- | --- |
 | `pages`                   | 6     | yes  | yes   | yes       | yes     | yes |
 | `snapshot`                | 3     | yes  | yes   | yes       | yes     | yes |
-| `input`                   | 7     | yes  | yes   | yes       | yes     | yes |
+| `input`                   | 8     | yes  | yes   | yes       | yes     | yes |
 | `network`                 | 3     | -    | -     | yes       | yes     | yes |
 | `console`                 | 2     | -    | -     | yes       | yes     | yes |
 | `screenshot`              | 2     | yes  | yes   | yes       | yes     | yes |
@@ -210,6 +210,16 @@ Parameters:
 
 - `key` (string, required) - One key, optionally preceded by "+"-separated modifiers, such as "Escape", "Enter" or "ctrl+shift+t". Modifiers: ctrl, alt, shift, meta. Named keys: Enter, Return, NumpadEnter, Tab, Backspace, Delete, Insert, Space, Escape, Home, End, PageUp, PageDown, ArrowUp, ArrowDown, ArrowLeft, ArrowRight, F1-F12, Numpad0-Numpad9, Clear, Pause, Help, Cancel, Semicolon, Equals, Add, Subtract, Multiply, Divide, Decimal, Separator. Anything else must be a single character. Any number of modifiers, but only one key.
 - `uid` (string, optional) - Focusable element UID from snapshot to focus before pressing (default: the already focused element)
+
+### `type_text`
+
+Type text key by key into the focused element, optionally followed by a key such as Enter. Use fill_by_uid to set the value of a known input; use this for elements that only react to real typing, such as autocomplete fields and rich text editors.
+
+Parameters:
+
+- `text` (string, required) - Text to type
+- `uid` (string, optional) - Focusable element UID from snapshot to focus before typing (default: the already focused element)
+- `submitKey` (string, optional) - Key to press after the text, such as "Enter" or "Tab". Same syntax as press_key.
 
 ## network
 

--- a/plugins/firefox-devtools-mcp/skills/browser-automation/SKILL.md
+++ b/plugins/firefox-devtools-mcp/skills/browser-automation/SKILL.md
@@ -59,7 +59,7 @@ take_snapshot  # Get fresh UIDs
 | See DOM | `take_snapshot` |
 | Click | `click_by_uid` |
 | Hover | `hover_by_uid` |
-| Type | `fill_by_uid`, `fill_form_by_uid` |
+| Type | `fill_by_uid`, `fill_form_by_uid`, `type_text` |
 | Press key | `press_key` |
 | Drag | `drag_by_uid_to_uid` |
 | Dialogs | `accept_dialog`, `dismiss_dialog` |

--- a/src/firefox/dom.ts
+++ b/src/firefox/dom.ts
@@ -3,6 +3,7 @@
  */
 
 import { By, Key, WebDriver, WebElement } from 'selenium-webdriver';
+import type { Actions } from 'selenium-webdriver/lib/input.js';
 
 /**
  * Key names accepted by press_key. Names are matched case-insensitively.
@@ -129,6 +130,21 @@ export function parseKeyCombo(combo: string): KeyCombo {
   }
 
   return { modifiers, key };
+}
+
+/**
+ * Queue a key press on an action sequence: hold the modifiers, tap the key,
+ * then release the modifiers in reverse order.
+ */
+function appendKeyPress(actions: Actions, { modifiers, key }: KeyCombo): void {
+  for (const modifier of modifiers) {
+    actions.keyDown(modifier);
+  }
+  actions.keyDown(key);
+  actions.keyUp(key);
+  for (const modifier of [...modifiers].reverse()) {
+    actions.keyUp(modifier);
+  }
 }
 
 export class DomInteractions {
@@ -421,7 +437,7 @@ export class DomInteractions {
    * @param uid Element UID to focus first. Defaults to the focused element.
    */
   async pressKey(key: string, uid?: string): Promise<void> {
-    const { modifiers, key: mainKey } = parseKeyCombo(key);
+    const combo = parseKeyCombo(key);
 
     if (uid) {
       // If a uid was provided, focus the element first so that actions will be
@@ -430,13 +446,34 @@ export class DomInteractions {
     }
 
     const actions = this.driver.actions({ async: true });
-    for (const modifier of modifiers) {
-      actions.keyDown(modifier);
+    appendKeyPress(actions, combo);
+    await actions.perform();
+
+    await this.waitForEventsAfterAction();
+  }
+
+  /**
+   * Type text key by key, optionally followed by a single key press.
+   * @param text Text to type
+   * @param options.uid Element UID to focus first. Defaults to the focused element.
+   * @param options.submitKey Key to press after the text, such as "Enter" or "Tab"
+   */
+  async typeText(
+    text: string,
+    options: { uid?: string | undefined; submitKey?: string | undefined } = {}
+  ): Promise<void> {
+    // Parsed up front so that an invalid key fails before anything is typed.
+    const submit = options.submitKey === undefined ? undefined : parseKeyCombo(options.submitKey);
+
+    if (options.uid) {
+      await this.focusByUid(options.uid);
     }
-    actions.keyDown(mainKey);
-    actions.keyUp(mainKey);
-    for (const modifier of [...modifiers].reverse()) {
-      actions.keyUp(modifier);
+
+    // One sequence, so that the text and the key land on the same element.
+    const actions = this.driver.actions({ async: true });
+    actions.sendKeys(text);
+    if (submit) {
+      appendKeyPress(actions, submit);
     }
     await actions.perform();
 

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -220,6 +220,16 @@ export class FirefoxClient {
     return await this.dom.pressKey(key, uid);
   }
 
+  async typeText(
+    text: string,
+    options?: { uid?: string | undefined; submitKey?: string | undefined }
+  ): Promise<void> {
+    if (!this.dom) {
+      throw new Error('Not connected');
+    }
+    return await this.dom.typeText(text, options);
+  }
+
   // ============================================================================
   // Console
   // ============================================================================

--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -172,6 +172,35 @@ export const pressKeyTool = {
   },
 } satisfies ToolDefinition;
 
+export const typeTextTool = {
+  name: 'type_text',
+  description:
+    'Type text key by key into the focused element, optionally followed by a key such as Enter. Use fill_by_uid to set the value of a known input; use this for elements that only react to real typing, such as autocomplete fields and rich text editors.',
+  annotations: {
+    readOnlyHint: false,
+  },
+  inputSchema: {
+    type: 'object',
+    properties: {
+      text: {
+        type: 'string',
+        description: 'Text to type',
+      },
+      uid: {
+        type: 'string',
+        description:
+          'Focusable element UID from snapshot to focus before typing (default: the already focused element)',
+      },
+      submitKey: {
+        type: 'string',
+        description:
+          'Key to press after the text, such as "Enter" or "Tab". Same syntax as press_key.',
+      },
+    },
+    required: ['text'],
+  },
+} satisfies ToolDefinition;
+
 // Handlers
 export const handleClickByUid = defineToolHandler(async function handleClickByUid(
   args: unknown
@@ -367,6 +396,40 @@ export const handlePressKey = defineToolHandler(async function handlePressKey(
   }
 });
 
+export const handleTypeText = defineToolHandler(async function handleTypeText(
+  args: unknown
+): Promise<McpToolResponse> {
+  const { text, uid, submitKey } =
+    (args as { text: string; uid?: string; submitKey?: string }) || {};
+
+  if (!text || typeof text !== 'string') {
+    throw new Error('text parameter is required and must be a non-empty string');
+  }
+
+  if (uid !== undefined && (!uid || typeof uid !== 'string')) {
+    throw new Error('uid parameter must be a non-empty string');
+  }
+
+  if (submitKey !== undefined && (!submitKey || typeof submitKey !== 'string')) {
+    throw new Error('submitKey parameter must be a non-empty string');
+  }
+
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
+
+  try {
+    await firefox.typeText(text, { uid, submitKey });
+    const target = uid ? ` on ${uid}` : '';
+    const suffix = submitKey ? `, then ${submitKey}` : '';
+    return successResponse(`type_text ${text.length} chars${target}${suffix}`);
+  } catch (error) {
+    if (uid) {
+      throw handleUidError(error as Error, uid);
+    }
+    throw error;
+  }
+});
+
 export const module = defineModule({
   name: 'input',
   description:
@@ -379,5 +442,6 @@ export const module = defineModule({
     [fillFormByUidTool, handleFillFormByUid],
     [uploadFileByUidTool, handleUploadFileByUid],
     [pressKeyTool, handlePressKey],
+    [typeTextTool, handleTypeText],
   ],
 });

--- a/tests/firefox/type-text.test.ts
+++ b/tests/firefox/type-text.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for DomInteractions.typeText action sequencing
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { Key } from 'selenium-webdriver';
+import { DomInteractions } from '../../src/firefox/dom.js';
+
+interface MockActions {
+  keyDown: ReturnType<typeof vi.fn>;
+  keyUp: ReturnType<typeof vi.fn>;
+  sendKeys: ReturnType<typeof vi.fn>;
+  perform: ReturnType<typeof vi.fn>;
+}
+
+function createDriver(focusResult: unknown = true) {
+  const calls: Array<[string, string]> = [];
+  const actions: MockActions = {
+    keyDown: vi.fn((k: string) => {
+      calls.push(['keyDown', k]);
+      return actions;
+    }),
+    keyUp: vi.fn((k: string) => {
+      calls.push(['keyUp', k]);
+      return actions;
+    }),
+    sendKeys: vi.fn((text: string) => {
+      calls.push(['sendKeys', text]);
+      return actions;
+    }),
+    perform: vi.fn().mockResolvedValue(undefined),
+  };
+  const driver = {
+    actions: vi.fn(() => actions),
+    executeScript: vi.fn(async (script: string) =>
+      script.includes('activeElement') ? focusResult : undefined
+    ),
+  };
+  return { driver, actions, calls };
+}
+
+describe('DomInteractions.typeText', () => {
+  it('should type the text on the focused element', async () => {
+    const { driver, actions, calls } = createDriver();
+    const dom = new DomInteractions(driver as never);
+
+    await dom.typeText('hello');
+
+    expect(calls).toEqual([['sendKeys', 'hello']]);
+    expect(actions.perform).toHaveBeenCalledTimes(1);
+  });
+
+  it('should press the submit key after the text in the same sequence', async () => {
+    const { driver, actions, calls } = createDriver();
+    const dom = new DomInteractions(driver as never);
+
+    await dom.typeText('hello', { submitKey: 'Enter' });
+
+    expect(calls).toEqual([
+      ['sendKeys', 'hello'],
+      ['keyDown', Key.RETURN],
+      ['keyUp', Key.RETURN],
+    ]);
+    expect(actions.perform).toHaveBeenCalledTimes(1);
+  });
+
+  it('should hold modifiers of the submit key around it', async () => {
+    const { driver, calls } = createDriver();
+    const dom = new DomInteractions(driver as never);
+
+    await dom.typeText('hello', { submitKey: 'shift+Enter' });
+
+    expect(calls).toEqual([
+      ['sendKeys', 'hello'],
+      ['keyDown', Key.SHIFT],
+      ['keyDown', Key.RETURN],
+      ['keyUp', Key.RETURN],
+      ['keyUp', Key.SHIFT],
+    ]);
+  });
+
+  it('should focus a uid first and still type through the actions keyboard', async () => {
+    const { driver, calls } = createDriver();
+    const sendKeys = vi.fn();
+    const resolveUid = vi.fn().mockResolvedValue({ sendKeys, isDisplayed: async () => true });
+    const dom = new DomInteractions(driver as never, resolveUid);
+
+    await dom.typeText('hello', { uid: 'uid-1' });
+
+    expect(resolveUid).toHaveBeenCalledWith('uid-1');
+    expect(sendKeys).not.toHaveBeenCalled();
+    expect(calls).toEqual([['sendKeys', 'hello']]);
+  });
+
+  it('should reject a uid that cannot take focus before typing anything', async () => {
+    const { driver, calls } = createDriver(false);
+    const resolveUid = vi.fn().mockResolvedValue({ isDisplayed: async () => true });
+    const dom = new DomInteractions(driver as never, resolveUid);
+
+    await expect(dom.typeText('hello', { uid: 'uid-2' })).rejects.toThrow(
+      /uid-2 cannot receive keyboard focus/
+    );
+    expect(calls).toEqual([]);
+  });
+
+  it('should reject an invalid submit key before touching the driver', async () => {
+    const { driver, calls } = createDriver();
+    const dom = new DomInteractions(driver as never);
+
+    await expect(dom.typeText('hello', { submitKey: 'foobar' })).rejects.toThrow(
+      /unknown key "foobar"/
+    );
+    expect(calls).toEqual([]);
+    expect(driver.actions).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/type-text.integration.test.ts
+++ b/tests/integration/type-text.integration.test.ts
@@ -16,7 +16,7 @@ describe('type_text Integration Tests', () => {
 
   beforeAll(async () => {
     firefox = await createTestFirefox();
-  }, 30000);
+  });
 
   afterAll(async () => {
     await closeFirefox(firefox);

--- a/tests/integration/type-text.integration.test.ts
+++ b/tests/integration/type-text.integration.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Integration tests for type_text
+ * Tests with real Firefox browser in headless mode
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createTestFirefox, closeFirefox, waitForElementInSnapshot } from '../helpers/firefox.js';
+import type { FirefoxClient } from '@/firefox/index.js';
+
+const PAGE =
+  'data:text/html,<h1 id=h>Title</h1><input id=a><input id=b>' +
+  '<form id=f onsubmit="document.title=\'submitted\';return false"><input id=c></form>';
+
+describe('type_text Integration Tests', () => {
+  let firefox: FirefoxClient;
+
+  beforeAll(async () => {
+    firefox = await createTestFirefox();
+  }, 30000);
+
+  afterAll(async () => {
+    await closeFirefox(firefox);
+  });
+
+  async function openPage(): Promise<void> {
+    await firefox.navigate(PAGE);
+    await firefox.evaluate(`
+      window.__keys = [];
+      document.addEventListener('keydown', (e) => {
+        window.__keys.push({ target: e.target.id, key: e.key });
+      }, true);
+    `);
+  }
+
+  async function recordedKeys(): Promise<Array<{ target: string; key: string }>> {
+    return JSON.parse(String(await firefox.evaluate('JSON.stringify(window.__keys)')));
+  }
+
+  async function valueOf(id: string): Promise<string> {
+    return String(await firefox.evaluate(`document.getElementById('${id}').value`));
+  }
+
+  async function uidOf(id: string): Promise<string> {
+    const node = await waitForElementInSnapshot(firefox, (n) => n.id === id, 10000);
+    return node.uid;
+  }
+
+  it('should type into the given uid one keydown per character', async () => {
+    await openPage();
+
+    await firefox.typeText('hi!', { uid: await uidOf('a') });
+
+    expect(await valueOf('a')).toBe('hi!');
+    expect((await recordedKeys()).map((k) => `${k.target}:${k.key}`)).toEqual([
+      'a:h',
+      'a:i',
+      'a:!',
+    ]);
+  }, 20000);
+
+  it('should append to the already focused element when no uid is given', async () => {
+    await openPage();
+
+    await firefox.typeText('ab', { uid: await uidOf('b') });
+    await firefox.typeText('cd');
+
+    expect(await valueOf('b')).toBe('abcd');
+  }, 20000);
+
+  it('should press the submit key on the same element after the text', async () => {
+    await openPage();
+
+    await firefox.typeText('query', { uid: await uidOf('c'), submitKey: 'Enter' });
+
+    expect(await valueOf('c')).toBe('query');
+    expect((await recordedKeys()).map((k) => k.key)).toEqual(['q', 'u', 'e', 'r', 'y', 'Enter']);
+    expect(await firefox.evaluate('document.title')).toBe('submitted');
+  }, 20000);
+
+  it('should move focus with Tab as the submit key', async () => {
+    await openPage();
+
+    await firefox.typeText('first', { uid: await uidOf('a'), submitKey: 'Tab' });
+
+    expect(await valueOf('a')).toBe('first');
+    expect(await firefox.evaluate('document.activeElement.id')).toBe('b');
+  }, 20000);
+
+  it('should reject a uid that cannot take keyboard focus without typing', async () => {
+    await openPage();
+    const uid = await uidOf('h');
+
+    await expect(firefox.typeText('nope', { uid })).rejects.toThrow(
+      /cannot receive keyboard focus/
+    );
+    expect(await recordedKeys()).toEqual([]);
+  }, 20000);
+});

--- a/tests/tools/input.test.ts
+++ b/tests/tools/input.test.ts
@@ -11,6 +11,7 @@ import {
   fillFormByUidTool,
   uploadFileByUidTool,
   pressKeyTool,
+  typeTextTool,
 } from '../../src/tools/input.js';
 
 function textOf(result: { content: unknown[] }): string {
@@ -27,6 +28,7 @@ describe('Input Tools', () => {
       expect(fillFormByUidTool.name).toBe('fill_form_by_uid');
       expect(uploadFileByUidTool.name).toBe('upload_file_by_uid');
       expect(pressKeyTool.name).toBe('press_key');
+      expect(typeTextTool.name).toBe('type_text');
     });
 
     it('should have valid descriptions', () => {
@@ -37,6 +39,7 @@ describe('Input Tools', () => {
       expect(fillFormByUidTool.description).toContain('form');
       expect(uploadFileByUidTool.description).toContain('Upload');
       expect(pressKeyTool.description).toContain('Press');
+      expect(typeTextTool.description).toContain('Type');
     });
 
     it('should steer press_key away from entering text', () => {
@@ -52,6 +55,7 @@ describe('Input Tools', () => {
       expect(fillFormByUidTool.inputSchema.type).toBe('object');
       expect(uploadFileByUidTool.inputSchema.type).toBe('object');
       expect(pressKeyTool.inputSchema.type).toBe('object');
+      expect(typeTextTool.inputSchema.type).toBe('object');
     });
   });
 
@@ -112,6 +116,15 @@ describe('Input Tools', () => {
       expect(properties?.key.type).toBe('string');
       expect(properties?.uid.type).toBe('string');
       expect(required).toEqual(['key']);
+    });
+
+    it('typeTextTool should require text and accept an optional uid and submitKey', () => {
+      const { properties, required } = typeTextTool.inputSchema;
+      expect(properties).toBeDefined();
+      expect(properties?.text.type).toBe('string');
+      expect(properties?.uid.type).toBe('string');
+      expect(properties?.submitKey.type).toBe('string');
+      expect(required).toEqual(['text']);
     });
   });
 
@@ -188,6 +201,77 @@ describe('Input Tools', () => {
 
       expect(result.isError).toBe(true);
       expect(textOf(result)).toContain('unknown key "foobar"');
+    });
+  });
+
+  describe('handleTypeText', () => {
+    let typeText: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      vi.resetModules();
+      typeText = vi.fn().mockResolvedValue(undefined);
+      vi.doMock('../../src/index.js', () => ({
+        args: {},
+        getFirefox: vi.fn().mockResolvedValue({ typeText }),
+      }));
+    });
+
+    afterEach(() => {
+      vi.doUnmock('../../src/index.js');
+      vi.restoreAllMocks();
+    });
+
+    it('should type into the focused element when no uid is given', async () => {
+      const { handleTypeText } = await import('../../src/tools/input.js');
+      const result = await handleTypeText({ text: 'hello' });
+
+      expect(result.isError).toBeUndefined();
+      expect(typeText).toHaveBeenCalledWith('hello', { uid: undefined, submitKey: undefined });
+      expect(textOf(result)).toContain('5 chars');
+    });
+
+    it('should pass uid and submitKey through', async () => {
+      const { handleTypeText } = await import('../../src/tools/input.js');
+      const result = await handleTypeText({ text: 'hello', uid: 'uid-3', submitKey: 'Enter' });
+
+      expect(result.isError).toBeUndefined();
+      expect(typeText).toHaveBeenCalledWith('hello', { uid: 'uid-3', submitKey: 'Enter' });
+      expect(textOf(result)).toContain('uid-3');
+      expect(textOf(result)).toContain('Enter');
+    });
+
+    it('should reject missing, empty or non-string text', async () => {
+      const { handleTypeText } = await import('../../src/tools/input.js');
+
+      for (const args of [{}, { text: '' }, { text: 42 }]) {
+        const result = await handleTypeText(args);
+        expect(result.isError).toBe(true);
+        expect(textOf(result)).toContain('text parameter is required');
+      }
+      expect(typeText).not.toHaveBeenCalled();
+    });
+
+    it('should reject an empty uid or submitKey', async () => {
+      const { handleTypeText } = await import('../../src/tools/input.js');
+
+      const withUid = await handleTypeText({ text: 'x', uid: '' });
+      expect(withUid.isError).toBe(true);
+      expect(textOf(withUid)).toContain('uid parameter must be a non-empty string');
+
+      const withKey = await handleTypeText({ text: 'x', submitKey: '' });
+      expect(withKey.isError).toBe(true);
+      expect(textOf(withKey)).toContain('submitKey parameter must be a non-empty string');
+
+      expect(typeText).not.toHaveBeenCalled();
+    });
+
+    it('should report a stale uid as such', async () => {
+      typeText.mockRejectedValue(new Error('UID uid-9 not found in snapshot'));
+      const { handleTypeText } = await import('../../src/tools/input.js');
+      const result = await handleTypeText({ text: 'x', uid: 'uid-9' });
+
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toContain('take_snapshot');
     });
   });
 });


### PR DESCRIPTION
Adds `type_text`, a companion to `press_key` for elements that only react to real key-by-key typing (autocomplete fields, rich text editors).

- `text` (required), `uid` (optional, focused first like `press_key`), `submitKey` (optional, same syntax as `press_key`)
- Text and submit key run in one action sequence, so the key lands on the same element
- Reuses `parseKeyCombo` and the focus handling from #82; the key press sequencing is shared with `press_key`
- Unit tests for the handler and the action sequence, integration tests against a real Firefox, `docs/tools.md` regenerated
