### PR TITLE
chore: enforce LF line endings with gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Enforcing LF line endings with gitattributes to avoid linting errors on other platforms (ie. windows).