### PR TITLE
test: make process cleanup work on Windows

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -83,7 +83,7 @@ function findWindowsProcessIds(imageName: string, commandLinePattern?: string): 
   const output = execFileSync(
     'powershell.exe',
     ['-NoProfile', '-NonInteractive', '-Command', script],
-    { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }
+    { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], windowsHide: true }
   );
   return output
     .split(/\r?\n/)

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -71,8 +71,10 @@ function cleanupUnix() {
   }
 }
 
-// Only matches Firefox instances whose command line carries --marionette,
-// so regular user-launched Firefox windows are never touched.
+/**
+ * Windows only. Retrieve all process ids matching the provided name and
+ * optional command line pattern.
+ */
 function findWindowsProcessIds(imageName: string, commandLinePattern?: string): number[] {
   const filter = commandLinePattern
     ? `Name='${imageName}' AND CommandLine LIKE '%${commandLinePattern}%'`

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,7 +2,9 @@
 // This file runs before all tests
 
 import { beforeAll, afterAll } from 'vitest';
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
+
+const isWindows = process.platform === 'win32';
 
 // Track if we're in cleanup mode
 let isCleaningUp = false;
@@ -17,7 +19,7 @@ afterAll(() => {
 });
 
 /**
- * Cleanup function to kill all Firefox and geckodriver processes
+ * Cleanup function to kill leftover test Firefox and geckodriver processes
  * This ensures no zombie processes are left after test runs
  */
 function cleanup() {
@@ -26,6 +28,20 @@ function cleanup() {
   }
   isCleaningUp = true;
 
+  try {
+    if (isWindows) {
+      cleanupWindows();
+    } else {
+      cleanupUnix();
+    }
+  } catch {
+    // Ignore errors - processes might already be dead
+  } finally {
+    isCleaningUp = false;
+  }
+}
+
+function cleanupUnix() {
   try {
     // Find Firefox processes started with --marionette (test instances)
     const firefoxPids = execSync('pgrep -f "firefox.*marionette" || true', {
@@ -57,8 +73,55 @@ function cleanup() {
     console.log('✅ Global cleanup: All test Firefox processes terminated');
   } catch {
     // Ignore errors - processes might already be dead
-  } finally {
-    isCleaningUp = false;
+  }
+}
+
+// Only matches Firefox instances whose command line carries --marionette,
+// so regular user-launched Firefox windows are never touched.
+function findWindowsProcessIds(imageName: string, commandLinePattern?: string): number[] {
+  const filter = commandLinePattern
+    ? `Name='${imageName}' AND CommandLine LIKE '%${commandLinePattern}%'`
+    : `Name='${imageName}'`;
+  const script =
+    `Get-CimInstance Win32_Process -Filter "${filter}" | ` +
+    'Select-Object -ExpandProperty ProcessId';
+  const output = execFileSync(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-Command', script],
+    { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }
+  );
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => /^\d+$/.test(line))
+    .map(Number);
+}
+
+function cleanupWindows() {
+  try {
+    const firefoxPids = findWindowsProcessIds('firefox.exe', '--marionette');
+    for (const pid of firefoxPids) {
+      try {
+        // /T kills the whole process tree, replacing the Unix child-kill step
+        execSync(`taskkill /PID ${pid} /T /F`, { stdio: 'ignore' });
+      } catch {
+        // Ignore errors - process might already be dead
+      }
+    }
+
+    for (const pid of findWindowsProcessIds('geckodriver.exe')) {
+      try {
+        execSync(`taskkill /PID ${pid} /T /F`, { stdio: 'ignore' });
+      } catch {
+        // Ignore errors - process might already be dead
+      }
+    }
+
+    if (firefoxPids.length > 0) {
+      console.log('✅ Global cleanup: All test Firefox processes terminated');
+    }
+  } catch {
+    // Ignore errors - processes might already be dead
   }
 }
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -28,17 +28,12 @@ function cleanup() {
   }
   isCleaningUp = true;
 
-  try {
-    if (isWindows) {
-      cleanupWindows();
-    } else {
-      cleanupUnix();
-    }
-  } catch {
-    // Ignore errors - processes might already be dead
-  } finally {
-    isCleaningUp = false;
+  if (isWindows) {
+    cleanupWindows();
+  } else {
+    cleanupUnix();
   }
+  isCleaningUp = false;
 }
 
 function cleanupUnix() {


### PR DESCRIPTION
## Summary

Make the Vitest cleanup work properly on Windows.

The current cleanup uses Unix-only commands like `pgrep`, `pkill`, and `kill`, so running the tests on Windows prints command errors even though the tests themselves still run.

This change keeps the existing cleanup behavior for Linux and macOS, while adding a Windows-specific cleanup path. On Windows, it finds Firefox test instances using the `--marionette` command-line argument, terminates those process trees with `taskkill`, and cleans up leftover `geckodriver.exe` processes without touching normal Firefox windows.