### PR TITLE
Bug 2065546 - [firefox-devtools-mcp] navigate should accept an option to wait for load

### DIFF
--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -11,7 +11,7 @@ import { remoteValueToNative } from '../utils/remote-value.js';
 import { ConsoleEvents, NetworkEvents, DebuggingEvents, DownloadEvents } from './events/index.js';
 import type { NetworkBodyResult } from './events/network.js';
 import { DomInteractions } from './dom.js';
-import { PageManagement } from './pages.js';
+import { PageManagement, type ReadinessState } from './pages.js';
 import { SnapshotManager, type Snapshot, type SnapshotOptions } from './snapshot/index.js';
 
 /**
@@ -232,11 +232,11 @@ export class FirefoxClient {
   // Pages / Navigation
   // ============================================================================
 
-  async navigate(url: string): Promise<void> {
+  async navigate(url: string, wait?: ReadinessState): Promise<void> {
     if (!this.pages) {
       throw new Error('Not connected');
     }
-    await this.pages.navigate(url);
+    await this.pages.navigate(url, wait);
   }
 
   async navigateBack(): Promise<void> {
@@ -302,11 +302,11 @@ export class FirefoxClient {
     return await this.pages.selectTab(index);
   }
 
-  async createNewPage(url: string): Promise<number> {
+  async createNewPage(url: string, wait?: ReadinessState): Promise<number> {
     if (!this.pages) {
       throw new Error('Not connected');
     }
-    return await this.pages.createNewPage(url);
+    return await this.pages.createNewPage(url, wait);
   }
 
   async closeTab(index: number): Promise<void> {

--- a/src/firefox/pages.ts
+++ b/src/firefox/pages.ts
@@ -21,6 +21,20 @@ export function isCommonScheme(url: string): boolean {
 
 export type BiDiCommandFn = (method: string, params: Record<string, any>) => Promise<any>;
 
+/**
+ * WebDriver BiDi browsingContext.ReadinessState.
+ * - "none": return as soon as navigation starts
+ * - "interactive": wait for DOMContentLoaded
+ * - "complete": wait for the load event, including subresources
+ */
+export const READINESS_STATES = ['none', 'interactive', 'complete'] as const;
+
+export type ReadinessState = (typeof READINESS_STATES)[number];
+
+export function isReadinessState(value: unknown): value is ReadinessState {
+  return READINESS_STATES.includes(value as ReadinessState);
+}
+
 export class PageManagement {
   constructor(
     private driver: WebDriver,
@@ -31,16 +45,22 @@ export class PageManagement {
 
   /**
    * Navigate to URL using BiDi
+   *
+   * @param url - Target URL
+   * @param waitOverride - Explicit readiness state to wait for. When omitted,
+   *   common schemes wait for "interactive" and uncommon schemes do not wait.
    */
-  async navigate(url: string): Promise<void> {
+  async navigate(url: string, waitOverride?: ReadinessState): Promise<void> {
     const contextId = this.getCurrentContextId();
     if (!contextId) {
       throw new Error(`Cannot navigate: no browsing context ID`);
     }
 
     // Default wait time is "interactive" (DOMContentLoaded).
-    // All uncommon schemes use wait time "none"
-    const wait = isCommonScheme(url) ? 'interactive' : 'none';
+    // All uncommon schemes use wait time "none".
+    // An explicit override is honoured for every scheme: silently downgrading it
+    // would discard what the caller asked for with no way to tell.
+    const wait: ReadinessState = waitOverride ?? (isCommonScheme(url) ? 'interactive' : 'none');
 
     // Navigate using direct BiDi
     await this.sendBiDiCommand('browsingContext.navigate', {
@@ -186,13 +206,13 @@ export class PageManagement {
   /**
    * Create new page (tab)
    */
-  async createNewPage(url: string): Promise<number> {
+  async createNewPage(url: string, waitOverride?: ReadinessState): Promise<number> {
     await this.driver.switchTo().newWindow('tab');
     const handles = await this.driver.getAllWindowHandles();
     const newIdx = handles.length - 1;
     this.setCurrentContextId(handles[newIdx]!);
     this.cachedSelectedIdx = newIdx;
-    await this.navigate(url);
+    await this.navigate(url, waitOverride);
     return newIdx;
   }
 

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -10,9 +10,45 @@ import {
 } from '../utils/response-helpers.js';
 import { saveOutput } from '../utils/save-output.js';
 import { defineModule } from './module.js';
+import { READINESS_STATES, isReadinessState, type ReadinessState } from '../firefox/pages.js';
 import type { McpToolResponse } from '../types/common.js';
 
 const DEFAULT_MAX_CONTENT_CHARS = 20_000;
+
+const WAIT_DESCRIPTION =
+  "When to return: 'none' (navigation started), 'interactive' (DOMContentLoaded), " +
+  "'complete' (load event fired, including subresources). Omit for the default: " +
+  "'interactive' for http/https/data/blob/file, 'none' for other schemes. Use " +
+  "'complete' when the page must be fully loaded, e.g. before stopping a performance recording.";
+
+const waitSchema = {
+  type: 'string',
+  enum: [...READINESS_STATES],
+  description: WAIT_DESCRIPTION,
+};
+
+/**
+ * Validate the optional `wait` argument.
+ *
+ * An unknown value is rejected rather than ignored: silently falling back to the
+ * default would leave the caller believing it waited for something it did not.
+ */
+function parseWait(value: unknown): ReadinessState | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (!isReadinessState(value)) {
+    throw new Error(
+      `wait must be one of ${READINESS_STATES.join(', ')} (got ${JSON.stringify(value)})`
+    );
+  }
+  return value;
+}
+
+/** Echo the readiness state back only when the caller asked for one. */
+function waitSuffix(wait: ReadinessState | undefined): string {
+  return wait ? ` (waited for: ${wait})` : '';
+}
 
 // Tool definitions
 export const listPagesTool = {
@@ -40,6 +76,7 @@ export const newPageTool = {
         type: 'string',
         description: 'Target URL',
       },
+      wait: waitSchema,
     },
     required: ['url'],
   },
@@ -58,6 +95,7 @@ export const navigatePageTool = {
         type: 'string',
         description: 'Target URL',
       },
+      wait: waitSchema,
     },
     required: ['url'],
   },
@@ -175,18 +213,20 @@ export async function handleListPages(_args: unknown): Promise<McpToolResponse> 
 
 export async function handleNewPage(args: unknown): Promise<McpToolResponse> {
   try {
-    const { url } = args as { url: string };
+    const { url, wait } = args as { url: string; wait?: unknown };
 
     if (!url || typeof url !== 'string') {
       throw new Error('url parameter is required and must be a string');
     }
 
+    const waitFor = parseWait(wait);
+
     const { getFirefox } = await import('../index.js');
     const firefox = await getFirefox();
 
-    const newIdx = await firefox.createNewPage(url);
+    const newIdx = await firefox.createNewPage(url, waitFor);
 
-    return successResponse(`new page [${newIdx}] → ${url}`);
+    return successResponse(`new page [${newIdx}] → ${url}${waitSuffix(waitFor)}`);
   } catch (error) {
     return errorResponse(error as Error);
   }
@@ -194,11 +234,13 @@ export async function handleNewPage(args: unknown): Promise<McpToolResponse> {
 
 export async function handleNavigatePage(args: unknown): Promise<McpToolResponse> {
   try {
-    const { url } = args as { url: string };
+    const { url, wait } = args as { url: string; wait?: unknown };
 
     if (!url || typeof url !== 'string') {
       throw new Error('url parameter is required and must be a string');
     }
+
+    const waitFor = parseWait(wait);
 
     const { getFirefox } = await import('../index.js');
     const firefox = await getFirefox();
@@ -213,9 +255,9 @@ export async function handleNavigatePage(args: unknown): Promise<McpToolResponse
       throw new Error('No page selected');
     }
 
-    await firefox.navigate(url);
+    await firefox.navigate(url, waitFor);
 
-    return successResponse(`[${selectedIdx}] → ${url}`);
+    return successResponse(`[${selectedIdx}] → ${url}${waitSuffix(waitFor)}`);
   } catch (error) {
     return errorResponse(error as Error);
   }

--- a/tests/firefox/pages.test.ts
+++ b/tests/firefox/pages.test.ts
@@ -7,7 +7,12 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { isCommonScheme, PageManagement } from '@/firefox/pages.js';
+import {
+  isCommonScheme,
+  isReadinessState,
+  PageManagement,
+  READINESS_STATES,
+} from '@/firefox/pages.js';
 
 const HTTPS_URL = 'https://example.com/test.html';
 const HTTP_URL = 'http://example.com/test.html';
@@ -35,6 +40,22 @@ describe('isCommonScheme', () => {
 
   it('returns false for malformed URLs', () => {
     expect(isCommonScheme('not-a-url')).toBe(false);
+  });
+});
+
+describe('isReadinessState', () => {
+  it('accepts the three BiDi readiness states', () => {
+    expect(READINESS_STATES).toEqual(['none', 'interactive', 'complete']);
+    for (const state of READINESS_STATES) {
+      expect(isReadinessState(state)).toBe(true);
+    }
+  });
+
+  it('rejects anything else, including the DOM event name "load"', () => {
+    expect(isReadinessState('load')).toBe(false);
+    expect(isReadinessState('COMPLETE')).toBe(false);
+    expect(isReadinessState(undefined)).toBe(false);
+    expect(isReadinessState(true)).toBe(false);
   });
 });
 
@@ -128,6 +149,57 @@ describe('PageManagement', () => {
         wait: 'none',
       });
     });
+
+    it('honours an explicit wait for common schemes', async () => {
+      const { pages, sendBiDiCommand } = createMocks();
+
+      await pages.navigate(HTTPS_URL, 'complete');
+      expect(sendBiDiCommand).toHaveBeenCalledWith('browsingContext.navigate', {
+        context: 'ctx-1',
+        url: HTTPS_URL,
+        wait: 'complete',
+      });
+    });
+
+    it('honours an explicit wait for uncommon schemes rather than downgrading it', async () => {
+      const { pages, sendBiDiCommand } = createMocks();
+
+      await pages.navigate(MOZ_EXT_URL, 'complete');
+      expect(sendBiDiCommand).toHaveBeenCalledWith('browsingContext.navigate', {
+        context: 'ctx-1',
+        url: MOZ_EXT_URL,
+        wait: 'complete',
+      });
+
+      await pages.navigate('about:blank', 'interactive');
+      expect(sendBiDiCommand).toHaveBeenCalledWith('browsingContext.navigate', {
+        context: 'ctx-1',
+        url: 'about:blank',
+        wait: 'interactive',
+      });
+    });
+
+    it('allows an explicit wait to opt out of waiting on a common scheme', async () => {
+      const { pages, sendBiDiCommand } = createMocks();
+
+      await pages.navigate(HTTPS_URL, 'none');
+      expect(sendBiDiCommand).toHaveBeenCalledWith('browsingContext.navigate', {
+        context: 'ctx-1',
+        url: HTTPS_URL,
+        wait: 'none',
+      });
+    });
+
+    it('keeps the scheme-based default when no wait is given', async () => {
+      const { pages, sendBiDiCommand } = createMocks();
+
+      await pages.navigate(HTTPS_URL, undefined);
+      expect(sendBiDiCommand).toHaveBeenCalledWith('browsingContext.navigate', {
+        context: 'ctx-1',
+        url: HTTPS_URL,
+        wait: 'interactive',
+      });
+    });
   });
 
   describe('createNewPage', () => {
@@ -168,6 +240,33 @@ describe('PageManagement', () => {
         context: 'handle-2',
         url: MOZ_EXT_URL,
         wait: 'none',
+      });
+    });
+
+    it('forwards an explicit wait override to navigate', async () => {
+      const switchToMock = vi
+        .fn()
+        .mockReturnValue({ newWindow: vi.fn().mockResolvedValue(undefined) });
+      const getAllWindowHandlesMock = vi.fn().mockResolvedValue(['handle-1', 'handle-2']);
+
+      const driver = {
+        switchTo: switchToMock,
+        getAllWindowHandles: getAllWindowHandlesMock,
+      } as any;
+
+      const sendBiDiCommand = vi.fn().mockResolvedValue({});
+      const pages = new PageManagement(
+        driver,
+        vi.fn().mockReturnValue('handle-2'),
+        vi.fn(),
+        sendBiDiCommand
+      );
+
+      await pages.createNewPage(HTTPS_URL, 'complete');
+      expect(sendBiDiCommand).toHaveBeenCalledWith('browsingContext.navigate', {
+        context: 'handle-2',
+        url: HTTPS_URL,
+        wait: 'complete',
       });
     });
   });

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -64,6 +64,20 @@ describe('Pages Tools', () => {
       expect(properties?.url).toBeDefined();
     });
 
+    it.each([
+      ['navigatePageTool', navigatePageTool],
+      ['newPageTool', newPageTool],
+    ])('%s should expose an optional wait enum', (_name, tool) => {
+      const schema = tool.inputSchema as {
+        properties?: Record<string, any>;
+        required?: string[];
+      };
+      expect(schema.properties?.wait).toBeDefined();
+      expect(schema.properties?.wait.type).toBe('string');
+      expect(schema.properties?.wait.enum).toEqual(['none', 'interactive', 'complete']);
+      expect(schema.required).not.toContain('wait');
+    });
+
     it('closePageTool should require pageIdx', () => {
       const { properties, required } = closePageTool.inputSchema;
       expect(properties).toBeDefined();
@@ -146,6 +160,66 @@ describe('Pages Tools', () => {
 
       const text = (result.content[0] as { type: 'text'; text: string }).text;
       expect(text).toContain('Preview:');
+    });
+  });
+
+  describe('Navigation handlers: wait argument', () => {
+    let navigate: ReturnType<typeof vi.fn>;
+    let createNewPage: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      navigate = vi.fn().mockResolvedValue(undefined);
+      createNewPage = vi.fn().mockResolvedValue(1);
+
+      vi.doMock('../../src/index.js', () => ({
+        args: {},
+        getFirefox: vi.fn().mockResolvedValue({
+          navigate,
+          createNewPage,
+          refreshTabs: vi.fn().mockResolvedValue(undefined),
+          getTabs: vi.fn().mockReturnValue([{ url: 'about:blank', title: 'blank' }]),
+          getSelectedTabIdx: vi.fn().mockReturnValue(0),
+        }),
+      }));
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      vi.resetModules();
+    });
+
+    it('passes an explicit wait through to navigate', async () => {
+      const { handleNavigatePage } = await import('../../src/tools/pages.js');
+      const result = await handleNavigatePage({ url: 'https://example.com', wait: 'complete' });
+
+      expect(navigate).toHaveBeenCalledWith('https://example.com', 'complete');
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain('waited for: complete');
+    });
+
+    it('leaves the default in place when wait is omitted', async () => {
+      const { handleNavigatePage } = await import('../../src/tools/pages.js');
+      const result = await handleNavigatePage({ url: 'https://example.com' });
+
+      expect(navigate).toHaveBeenCalledWith('https://example.com', undefined);
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).not.toContain('waited for');
+    });
+
+    it('passes an explicit wait through to new_page', async () => {
+      const { handleNewPage } = await import('../../src/tools/pages.js');
+      await handleNewPage({ url: 'https://example.com', wait: 'complete' });
+
+      expect(createNewPage).toHaveBeenCalledWith('https://example.com', 'complete');
+    });
+
+    it('rejects an unknown wait value instead of silently ignoring it', async () => {
+      const { handleNavigatePage } = await import('../../src/tools/pages.js');
+      const result = await handleNavigatePage({ url: 'https://example.com', wait: 'load' });
+
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain('wait must be one of none, interactive, complete');
+      expect(navigate).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
`navigate` derives its readiness state from the URL scheme and gives the caller no say:

```js
// Default wait time is "interactive" (DOMContentLoaded).
// All uncommon schemes use wait time "none"
const wait = isCommonScheme(url) ? 'interactive' : 'none';
```

So an agent cannot tell a page that has finished loading from one still fetching subresources — which is exactly the distinction Bug 2065546 needs for "when is it safe to stop the performance recording".

This adds an optional `wait` to `navigate_page` and `new_page`, exposing the three BiDi readiness states. **Omitting it keeps today's behaviour exactly**, so nothing changes for existing callers.

```js
{ "url": "https://example.com", "wait": "complete" }
```

### Two decisions worth flagging

**An explicit `wait` is honoured for every scheme, not just common ones.** The scheme heuristic only applies when no override is given. Silently downgrading `complete` to `none` because the URL happened to be `moz-extension:` would discard what the caller asked for with no way to tell — the same failure mode this bug is about. There is a test for it.

**An unknown value is rejected, not ignored.** `wait: "load"` is the obvious guess (it is the DOM event name, and the wire value is `complete`), and on `main` an unrecognised argument is silently dropped and `navigate_page` reports success:

```
[0] → https://example.com          ← main: "load" ignored, looks like it worked
wait must be one of none, interactive, complete (got "load")   ← this PR
```

The tool response also echoes the state back (`[0] → https://example.com (waited for: complete)`) but only when one was explicitly requested, so the default output is unchanged.

`new_page` gets the same argument because `createNewPage` calls `navigate` directly — an agent opening a tab has the same need. Happy to drop that half if you would rather keep the change to `navigate_page` alone.

### Verified against real Firefox

Local server, document commits immediately, `<img>` subresource stalls 3s. Median of 5 runs after 2 warm-up loads:

| `wait` | time | `document.readyState` |
|---|---|---|
| omitted (default) | 661ms | `interactive` |
| `'none'` | 524ms | `interactive` |
| `'interactive'` | 327ms | `interactive` |
| `'complete'` | **3220ms** | **`complete`** |

`complete` blocks on the stalled subresource; the default is unchanged. Separating `none` from `interactive` needs a *streamed* document rather than a stalled subresource — with a flushed 64KB first chunk and the body trickling for 3s, `none` returns at 1251ms (commit) while `interactive` waits 3044ms for DOMContentLoaded. Worth knowing that `none` returns on navigation commit, not instantly.

### A limit you should know about before taking this

**`wait: "complete"` is capped at 10 seconds** by the global BiDi command timeout at `src/firefox/bidi.ts:61`. On a page whose `load` fires later than that, `navigate` throws rather than waiting:

```
wait:interactive  OK after 1092ms   readyState=interactive
wait:complete     THREW after 10004ms  -> BiDi command timeout: browsingContext.navigate
```

(Measured with a 12s-stalled subresource.) This is pre-existing and applies to every BiDi command, but `complete` will hit it far more often than `interactive` does, and heavy real-world pages — ads, third-party trackers, video — routinely take longer than 10s to fire `load`.

I have **not** changed that timeout. Making it configurable, or special-casing `navigate`, is a decision about the BiDi layer that affects every command, and it is not mine to make inside a feature PR. Happy to follow up in whichever shape you prefer — a per-command override, a longer default for `navigate`, or leaving it and documenting the ceiling.

### Tests

12 new unit tests across `tests/firefox/pages.test.ts` and `tests/tools/pages.test.ts`. All 12 fail on unmodified `main`:

```
× isReadinessState > accepts the three BiDi readiness states
× isReadinessState > rejects anything else, including the DOM event name "load"
× PageManagement > navigate > honours an explicit wait for common schemes
× PageManagement > navigate > honours an explicit wait for uncommon schemes rather than downgrading it
× PageManagement > navigate > allows an explicit wait to opt out of waiting on a common scheme
× PageManagement > createNewPage > forwards an explicit wait override to navigate
× navigatePageTool should expose an optional wait enum
× newPageTool should expose an optional wait enum
× passes an explicit wait through to navigate
× leaves the default in place when wait is omitted
× passes an explicit wait through to new_page
× rejects an unknown wait value instead of silently ignoring it
```

**No integration test, deliberately.** I wrote one, and it passed on its own and alongside the other integration files — but under the full `vitest run` it intermittently failed with `BiDi command timeout: browsingContext.navigate`, because `wait: "complete"` holds a BiDi call open for the length of the stall and the suite was already contending for resources. Any stall long enough to reliably separate `complete` from `interactive` is long enough to risk that timeout under load. Given Bug 2036018 is already open about intermittent Firefox CI failures, adding a new source of flake seemed clearly worse than proving the behaviour with deterministic unit tests plus the measurements above. Say the word if you want it anyway and I will add it back.

```
npm run lint            clean
npm run format:check    clean
npm run typecheck       clean
npm run typecheck:tests clean
npm run build           clean
npx vitest run          50 files, 662 tests passed
```
