### PR TITLE
Bug 2065545 - [firefox-devtools-mcp] Add a tool to disable the network cache

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -2,7 +2,7 @@
 
 # Tool reference
 
-The server exposes 52 tools grouped into 16 modules. Which modules are
+The server exposes 53 tools grouped into 16 modules. Which modules are
 enabled depends on `--tool-preset` or `--tools`; see
 [Tool modules and presets](../README.md#tool-modules-and-presets) in the README.
 
@@ -16,7 +16,7 @@ Mozilla-internal build and `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1`; the public packag
 | `pages`                   | 6     | yes  | yes   | yes       | yes     | yes |
 | `snapshot`                | 3     | yes  | yes   | yes       | yes     | yes |
 | `input`                   | 7     | yes  | yes   | yes       | yes     | yes |
-| `network`                 | 2     | -    | -     | yes       | yes     | yes |
+| `network`                 | 3     | -    | -     | yes       | yes     | yes |
 | `console`                 | 2     | -    | -     | yes       | yes     | yes |
 | `screenshot`              | 2     | yes  | yes   | yes       | yes     | yes |
 | `downloads`               | 3     | -    | yes   | yes       | yes     | yes |
@@ -213,7 +213,7 @@ Parameters:
 
 ## network
 
-List and inspect network requests.
+List and inspect network requests, and control the HTTP cache.
 
 ### `list_network_requests`
 
@@ -251,6 +251,15 @@ Parameters:
 - `format` (`text` | `json`, optional) - Output format (default: text)
 - `saveTo` (boolean | string, optional) - Save the request details with full untruncated headers and bodies to a file as JSON instead of returning them inline (binary bodies are stored base64-encoded). Pass a file path, an existing directory (generated file inside), or true (generated file under ~/.firefox-devtools-mcp/output/). Relative paths resolve against the current working directory.
 - `preview` (number, optional) - Number of characters of the saved output to return inline as a preview when saveTo is used. Omit for no preview.
+
+### `set_network_cache`
+
+Control the HTTP cache. Use behavior='bypass' so every request goes to the network — useful for performance measurement and for verifying a change that a cached asset would otherwise hide. Applies to the currently selected tab unless scope='global'. Persists until set back to 'default' or Firefox shuts down.
+
+Parameters:
+
+- `behavior` (`default` | `bypass`, required) - 'bypass' to skip the cache, 'default' to restore normal caching
+- `scope` (`tab` | `global`, optional) - 'tab' (default) applies to the selected tab; 'global' applies browser-wide
 
 ## console
 

--- a/src/firefox/cache.ts
+++ b/src/firefox/cache.ts
@@ -1,0 +1,41 @@
+/**
+ * Network cache behaviour (WebDriver BiDi network.setCacheBehavior)
+ */
+
+export type BiDiCommandFn = (method: string, params: Record<string, any>) => Promise<any>;
+
+/**
+ * WebDriver BiDi network.CacheBehavior.
+ * - "default": normal HTTP cache behaviour
+ * - "bypass": skip the cache, so every request goes to the network
+ */
+export const CACHE_BEHAVIORS = ['default', 'bypass'] as const;
+
+export type CacheBehavior = (typeof CACHE_BEHAVIORS)[number];
+
+export function isCacheBehavior(value: unknown): value is CacheBehavior {
+  return CACHE_BEHAVIORS.includes(value as CacheBehavior);
+}
+
+export class CacheManagement {
+  constructor(
+    private getCurrentContextId: () => string | null,
+    private sendBiDiCommand: BiDiCommandFn
+  ) {}
+
+  async setCacheBehavior(behavior: CacheBehavior, options?: { global?: boolean }): Promise<void> {
+    const params: Record<string, unknown> = { cacheBehavior: behavior };
+
+    // Omitting `contexts` applies the behaviour globally; passing the current
+    // context scopes it to the selected tab, which is the default.
+    if (!options?.global) {
+      const contextId = this.getCurrentContextId();
+      if (!contextId) {
+        throw new Error('Cannot set cache behavior: no browsing context ID');
+      }
+      params.contexts = [contextId];
+    }
+
+    await this.sendBiDiCommand('network.setCacheBehavior', params);
+  }
+}

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -12,12 +12,8 @@ import { ConsoleEvents, NetworkEvents, DebuggingEvents, DownloadEvents } from '.
 import type { NetworkBodyResult } from './events/network.js';
 import { DomInteractions } from './dom.js';
 import { PageManagement, type ReadinessState } from './pages.js';
-import { CacheManagement, CACHE_BEHAVIORS, isCacheBehavior, type CacheBehavior } from './cache.js';
+import { CacheManagement, type CacheBehavior } from './cache.js';
 import { SnapshotManager, type Snapshot, type SnapshotOptions } from './snapshot/index.js';
-
-// Re-exported for backward compatibility: src/tools/network.ts imports
-// these cache types from firefox/index.js rather than firefox/cache.js.
-export { CACHE_BEHAVIORS, isCacheBehavior, type CacheBehavior };
 
 /**
  * Main Firefox Client facade

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -12,20 +12,12 @@ import { ConsoleEvents, NetworkEvents, DebuggingEvents, DownloadEvents } from '.
 import type { NetworkBodyResult } from './events/network.js';
 import { DomInteractions } from './dom.js';
 import { PageManagement, type ReadinessState } from './pages.js';
+import { CacheManagement, CACHE_BEHAVIORS, isCacheBehavior, type CacheBehavior } from './cache.js';
 import { SnapshotManager, type Snapshot, type SnapshotOptions } from './snapshot/index.js';
 
-/**
- * WebDriver BiDi network.CacheBehavior.
- * - "default": normal HTTP cache behaviour
- * - "bypass": skip the cache, so every request goes to the network
- */
-export const CACHE_BEHAVIORS = ['default', 'bypass'] as const;
-
-export type CacheBehavior = (typeof CACHE_BEHAVIORS)[number];
-
-export function isCacheBehavior(value: unknown): value is CacheBehavior {
-  return CACHE_BEHAVIORS.includes(value as CacheBehavior);
-}
+// Re-exported for backward compatibility: src/tools/network.ts imports
+// these cache types from firefox/index.js rather than firefox/cache.js.
+export { CACHE_BEHAVIORS, isCacheBehavior, type CacheBehavior };
 
 /**
  * Main Firefox Client facade
@@ -40,6 +32,7 @@ export class FirefoxClient {
   private downloadEvents: DownloadEvents | null = null;
   private dom: DomInteractions | null = null;
   private pages: PageManagement | null = null;
+  private cache: CacheManagement | null = null;
   private snapshot: SnapshotManager | null = null;
 
   constructor(options: FirefoxLaunchOptions) {
@@ -112,6 +105,11 @@ export class FirefoxClient {
       driver,
       () => this.core.getCurrentContextId(),
       (id: string) => this.core.setCurrentContextId(id),
+      (method: string, params: Record<string, any>) => this.getBidi().sendCommand(method, params)
+    );
+
+    this.cache = new CacheManagement(
+      () => this.core.getCurrentContextId(),
       (method: string, params: Record<string, any>) => this.getBidi().sendCommand(method, params)
     );
   }
@@ -341,19 +339,10 @@ export class FirefoxClient {
   // ============================================================================
 
   async setCacheBehavior(behavior: CacheBehavior, options?: { global?: boolean }): Promise<void> {
-    const params: Record<string, unknown> = { cacheBehavior: behavior };
-
-    // Omitting `contexts` applies the behaviour globally; passing the current
-    // context scopes it to the selected tab, which is the default.
-    if (!options?.global) {
-      const contextId = this.getCurrentContextId();
-      if (!contextId) {
-        throw new Error('Cannot set cache behavior: no browsing context ID');
-      }
-      params.contexts = [contextId];
+    if (!this.cache) {
+      throw new Error('Not connected');
     }
-
-    await this.sendBiDiCommand('network.setCacheBehavior', params);
+    await this.cache.setCacheBehavior(behavior, options);
   }
 
   async startNetworkMonitoring(): Promise<void> {
@@ -623,6 +612,7 @@ export class FirefoxClient {
     this.downloadEvents = null;
     this.dom = null;
     this.pages = null;
+    this.cache = null;
     this.snapshot = null;
   }
 }

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -15,6 +15,19 @@ import { PageManagement, type ReadinessState } from './pages.js';
 import { SnapshotManager, type Snapshot, type SnapshotOptions } from './snapshot/index.js';
 
 /**
+ * WebDriver BiDi network.CacheBehavior.
+ * - "default": normal HTTP cache behaviour
+ * - "bypass": skip the cache, so every request goes to the network
+ */
+export const CACHE_BEHAVIORS = ['default', 'bypass'] as const;
+
+export type CacheBehavior = (typeof CACHE_BEHAVIORS)[number];
+
+export function isCacheBehavior(value: unknown): value is CacheBehavior {
+  return CACHE_BEHAVIORS.includes(value as CacheBehavior);
+}
+
+/**
  * Main Firefox Client facade
  * Delegates to modular components for clean separation of concerns
  */
@@ -326,6 +339,22 @@ export class FirefoxClient {
   // ============================================================================
   // Network
   // ============================================================================
+
+  async setCacheBehavior(behavior: CacheBehavior, options?: { global?: boolean }): Promise<void> {
+    const params: Record<string, unknown> = { cacheBehavior: behavior };
+
+    // Omitting `contexts` applies the behaviour globally; passing the current
+    // context scopes it to the selected tab, which is the default.
+    if (!options?.global) {
+      const contextId = this.getCurrentContextId();
+      if (!contextId) {
+        throw new Error('Cannot set cache behavior: no browsing context ID');
+      }
+      params.contexts = [contextId];
+    }
+
+    await this.sendBiDiCommand('network.setCacheBehavior', params);
+  }
 
   async startNetworkMonitoring(): Promise<void> {
     if (!this.networkEvents) {

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -17,7 +17,7 @@ import { saveOutput } from '../utils/save-output.js';
 import { defineModule, defineToolHandler, type ToolDefinition } from './module.js';
 import type { McpToolResponse } from '../types/common.js';
 import type { NetworkBodyResult } from '../firefox/events/network.js';
-import { CACHE_BEHAVIORS, isCacheBehavior } from '../firefox/index.js';
+import { CACHE_BEHAVIORS, isCacheBehavior } from '../firefox/cache.js';
 
 // Tool definitions
 export const listNetworkRequestsTool = {
@@ -135,7 +135,7 @@ export const getNetworkRequestTool = {
 export const setNetworkCacheTool = {
   name: 'set_network_cache',
   description:
-    "Control the HTTP cache. Use behavior='bypass' so every request goes to the network — useful for performance measurement and for verifying a change that a cached asset would otherwise hide. Applies to the selected tab unless scope='global'. Persists until set back to 'default'.",
+    "Control the HTTP cache. Use behavior='bypass' so every request goes to the network — useful for performance measurement and for verifying a change that a cached asset would otherwise hide. Applies to the currently selected tab unless scope='global'. Persists until set back to 'default' or Firefox shuts down.",
   annotations: {
     readOnlyHint: false,
   },
@@ -602,8 +602,8 @@ export const handleGetNetworkRequest = defineToolHandler(
   }
 );
 
-export async function handleSetNetworkCache(args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleSetNetworkCache = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     const { behavior, scope } = (args as { behavior?: unknown; scope?: unknown }) || {};
 
     // An unrecognised value is rejected rather than defaulting: silently caching
@@ -628,10 +628,8 @@ export async function handleSetNetworkCache(args: unknown): Promise<McpToolRespo
       `cache ${behavior} (${isGlobal ? 'all tabs' : 'selected tab'})` +
         (behavior === 'bypass' ? " — set behavior='default' to restore caching" : '')
     );
-  } catch (error) {
-    return errorResponse(error instanceof Error ? error : new Error(String(error)));
   }
-}
+);
 
 export const module = defineModule({
   name: 'network',

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -140,7 +140,7 @@ export const setNetworkCacheTool = {
     readOnlyHint: false,
   },
   inputSchema: {
-    type: 'object' as const,
+    type: 'object',
     properties: {
       behavior: {
         type: 'string',
@@ -155,7 +155,7 @@ export const setNetworkCacheTool = {
     },
     required: ['behavior'],
   },
-};
+} satisfies ToolDefinition;
 
 /**
  * Fetch a body without letting a missing facade method or transport error fail

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -17,6 +17,7 @@ import { saveOutput } from '../utils/save-output.js';
 import { defineModule, defineToolHandler, type ToolDefinition } from './module.js';
 import type { McpToolResponse } from '../types/common.js';
 import type { NetworkBodyResult } from '../firefox/events/network.js';
+import { CACHE_BEHAVIORS, isCacheBehavior } from '../firefox/index.js';
 
 // Tool definitions
 export const listNetworkRequestsTool = {
@@ -130,6 +131,31 @@ export const getNetworkRequestTool = {
     },
   },
 } satisfies ToolDefinition;
+
+export const setNetworkCacheTool = {
+  name: 'set_network_cache',
+  description:
+    "Control the HTTP cache. Use behavior='bypass' so every request goes to the network — useful for performance measurement and for verifying a change that a cached asset would otherwise hide. Applies to the selected tab unless scope='global'. Persists until set back to 'default'.",
+  annotations: {
+    readOnlyHint: false,
+  },
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      behavior: {
+        type: 'string',
+        enum: [...CACHE_BEHAVIORS],
+        description: "'bypass' to skip the cache, 'default' to restore normal caching",
+      },
+      scope: {
+        type: 'string',
+        enum: ['tab', 'global'],
+        description: "'tab' (default) applies to the selected tab; 'global' applies browser-wide",
+      },
+    },
+    required: ['behavior'],
+  },
+};
 
 /**
  * Fetch a body without letting a missing facade method or transport error fail
@@ -576,11 +602,43 @@ export const handleGetNetworkRequest = defineToolHandler(
   }
 );
 
+export async function handleSetNetworkCache(args: unknown): Promise<McpToolResponse> {
+  try {
+    const { behavior, scope } = (args as { behavior?: unknown; scope?: unknown }) || {};
+
+    // An unrecognised value is rejected rather than defaulting: silently caching
+    // when the caller asked to bypass would quietly invalidate their measurement.
+    if (!isCacheBehavior(behavior)) {
+      return errorResponse(
+        `behavior must be one of ${CACHE_BEHAVIORS.join(', ')} (got ${JSON.stringify(behavior)})`
+      );
+    }
+    if (scope !== undefined && scope !== 'tab' && scope !== 'global') {
+      return errorResponse(`scope must be 'tab' or 'global' (got ${JSON.stringify(scope)})`);
+    }
+
+    const isGlobal = scope === 'global';
+
+    const { getFirefox } = await import('../index.js');
+    const firefox = await getFirefox();
+
+    await firefox.setCacheBehavior(behavior, { global: isGlobal });
+
+    return successResponse(
+      `cache ${behavior} (${isGlobal ? 'all tabs' : 'selected tab'})` +
+        (behavior === 'bypass' ? " — set behavior='default' to restore caching" : '')
+    );
+  } catch (error) {
+    return errorResponse(error instanceof Error ? error : new Error(String(error)));
+  }
+}
+
 export const module = defineModule({
   name: 'network',
-  description: 'List and inspect network requests.',
+  description: 'List and inspect network requests, and control the HTTP cache.',
   tools: [
     [listNetworkRequestsTool, handleListNetworkRequests],
     [getNetworkRequestTool, handleGetNetworkRequest],
+    [setNetworkCacheTool, handleSetNetworkCache],
   ],
 });

--- a/tests/tools/network.test.ts
+++ b/tests/tools/network.test.ts
@@ -6,7 +6,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { listNetworkRequestsTool, getNetworkRequestTool } from '../../src/tools/network.js';
+import {
+  listNetworkRequestsTool,
+  getNetworkRequestTool,
+  setNetworkCacheTool,
+} from '../../src/tools/network.js';
 
 describe('Network Tools', () => {
   describe('Tool Definitions', () => {
@@ -23,6 +27,77 @@ describe('Network Tools', () => {
     it('should have valid input schemas', () => {
       expect(listNetworkRequestsTool.inputSchema.type).toBe('object');
       expect(getNetworkRequestTool.inputSchema.type).toBe('object');
+    });
+  });
+
+  describe('set_network_cache', () => {
+    let setCacheBehavior: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      setCacheBehavior = vi.fn().mockResolvedValue(undefined);
+      vi.doMock('../../src/index.js', () => ({
+        args: {},
+        getFirefox: vi.fn().mockResolvedValue({ setCacheBehavior }),
+      }));
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      vi.resetModules();
+    });
+
+    const textOf = (r: { content: Array<{ type: string; text?: string }> }) =>
+      (r.content[0] as { type: 'text'; text: string }).text;
+
+    it('exposes a behavior enum and an optional scope', () => {
+      expect(setNetworkCacheTool.name).toBe('set_network_cache');
+      const { properties, required } = setNetworkCacheTool.inputSchema;
+      expect(properties?.behavior.enum).toEqual(['default', 'bypass']);
+      expect(properties?.scope.enum).toEqual(['tab', 'global']);
+      expect(required).toEqual(['behavior']);
+      expect(required).not.toContain('scope');
+    });
+
+    it('scopes to the selected tab by default', async () => {
+      const { handleSetNetworkCache } = await import('../../src/tools/network.js');
+      const result = await handleSetNetworkCache({ behavior: 'bypass' });
+
+      expect(setCacheBehavior).toHaveBeenCalledWith('bypass', { global: false });
+      expect(textOf(result)).toContain('selected tab');
+    });
+
+    it('applies browser-wide when scope is global', async () => {
+      const { handleSetNetworkCache } = await import('../../src/tools/network.js');
+      const result = await handleSetNetworkCache({ behavior: 'bypass', scope: 'global' });
+
+      expect(setCacheBehavior).toHaveBeenCalledWith('bypass', { global: true });
+      expect(textOf(result)).toContain('all tabs');
+    });
+
+    it('tells the caller how to restore caching after a bypass', async () => {
+      const { handleSetNetworkCache } = await import('../../src/tools/network.js');
+      const bypass = await handleSetNetworkCache({ behavior: 'bypass' });
+      expect(textOf(bypass)).toContain("behavior='default'");
+
+      const restore = await handleSetNetworkCache({ behavior: 'default' });
+      expect(setCacheBehavior).toHaveBeenLastCalledWith('default', { global: false });
+      expect(textOf(restore)).not.toContain("behavior='default' to restore");
+    });
+
+    it('rejects an unknown behavior instead of defaulting to cached', async () => {
+      const { handleSetNetworkCache } = await import('../../src/tools/network.js');
+      const result = await handleSetNetworkCache({ behavior: 'disabled' });
+
+      expect(textOf(result)).toContain('behavior must be one of default, bypass');
+      expect(setCacheBehavior).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown scope instead of silently using the tab', async () => {
+      const { handleSetNetworkCache } = await import('../../src/tools/network.js');
+      const result = await handleSetNetworkCache({ behavior: 'bypass', scope: 'everything' });
+
+      expect(textOf(result)).toContain("scope must be 'tab' or 'global'");
+      expect(setCacheBehavior).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Adds a `set_network_cache` tool so an agent can send every request to the network instead of the cache:

```js
{ "behavior": "bypass" }                    // selected tab
{ "behavior": "bypass", "scope": "global" } // browser-wide
{ "behavior": "default" }                   // restore
```

Per your note on the bug, this is a tool rather than a config, and it is scoped to the selected tab by default with `scope: "global"` as the opt-in. It joins the existing `network` module, so it arrives with the `developer` preset alongside the profiler tools it is meant to be used with.

### One correction to the bug, with evidence

The bug says:

> WebDriver BiDi supports the `emulation.setNetworkConditions` command, which allows to bypass the cache.

That command does exist in Firefox, but it has no cache parameter: it is offline emulation. Probed against Firefox 154 through this repo's own BiDi transport:

```
ERR   emulation.setNetworkConditions {contexts, cacheDisabled:true}  -> invalid argument
ERR   emulation.setNetworkConditions {contexts, offline:false}       -> invalid argument
ERR   emulation.setNetworkConditions {contexts, latency:0}           -> invalid argument
ERR   emulation.setNetworkConditions networkConditions:"offline"     -> invalid argument
OK    emulation.setNetworkConditions networkConditions:{type:"offline"}
OK    emulation.setNetworkConditions networkConditions:null
```

The only accepted values are `{type: "offline"}` and `null`.

I checked that `invalid argument` really meant "exists, wrong params" rather than "no such command", because reading it the other way would have sent me down the wrong path:

```
ERR   bogus.noSuchCommand                    -> unknown command
ERR   emulation.noSuchThing                  -> unknown command
ERR   emulation.setLocaleOverride {}         -> invalid argument   (real command, bad params)
```

The command that actually bypasses the cache is `network.setCacheBehavior`, with `cacheBehavior: "bypass" | "default"` and an optional `contexts`. Omit it for global; pass one for per-tab. That is what this PR wraps.

### Measured, not assumed

A local server serving `asset.js` with `Cache-Control: public, max-age=86400`, counting real server hits across 3 page loads:

| state | 3 loads → server hits |
|---|---|
| baseline (default) | **1** (cached) |
| `setCacheBehavior('bypass')`, tab-scoped | **3** (every load hit the network) |
| `setCacheBehavior('default')` restore | 0 (served from cache again) |
| `setCacheBehavior('bypass', {global:true})` | **3** |

Both scopes work, and the effect is reversible.

### Rejecting rather than defaulting

An unrecognised `behavior` or `scope` returns an error instead of falling back:

```
behavior must be one of default, bypass (got "disabled")
scope must be 'tab' or 'global' (got "everything")
```

Defaulting to `default` when someone asked for `disabled` would silently leave the cache on and quietly invalidate whatever they were measuring. This is the exact failure this tool exists to prevent. `bypass` also echoes back how to undo it, since the setting persists until reset:

```
cache bypass (selected tab): set behavior='default' to restore caching
```

### Tests

Six new unit tests in `tests/tools/network.test.ts`, all failing on unmodified `main`:

```
× exposes a behavior enum and an optional scope
× scopes to the selected tab by default
× applies browser-wide when scope is global
× tells the caller how to restore caching after a bypass
× rejects an unknown behavior instead of defaulting to cached
× rejects an unknown scope instead of silently using the tab
```

No integration test: the cache-bypass assertion needs a local HTTP server with a cacheable asset and a hit counter, which is a new pattern for `tests/integration/` (every file there uses `file://` fixtures, and `file://` cannot exercise the HTTP cache). I can add one if you would like that pattern introduced. The measurements above came from exactly that harness, so it is written.

```
npm run lint            clean
npm run format:check    clean
npm run typecheck       clean
npm run typecheck:tests clean
npm run build           clean
npm run test:unit       43 files, 601 tests passed
```

### Left alone deliberately

`emulation.setNetworkConditions` with `{type: "offline"}` is a genuinely useful thing to expose for offline-mode testing, but it is a different feature from this bug and would want its own tool and its own name. I can follow up if you want it.
