### PR TITLE
refactor: centralize tool handler error handling

### DIFF
--- a/src/tools/console.ts
+++ b/src/tools/console.ts
@@ -4,7 +4,6 @@
 
 import {
   successResponse,
-  errorResponse,
   jsonResponse,
   TOKEN_LIMITS,
   truncateText,
@@ -12,7 +11,11 @@ import {
   truncationFooter,
 } from '../utils/response-helpers.js';
 import { saveOutput } from '../utils/save-output.js';
+<<<<<<< HEAD
 import { defineModule, type ToolDefinition } from './module.js';
+=======
+import { defineModule, defineToolHandler } from './module.js';
+>>>>>>> 63301d6 (refactor: use shared errors in network, console, and download tools)
 import type { McpToolResponse } from '../types/common.js';
 
 export const listConsoleMessagesTool = {
@@ -91,8 +94,8 @@ function formatMessageLine(msg: {
   return `${time}${msg.level.toUpperCase()}${source}: ${msg.text}`;
 }
 
-export async function handleListConsoleMessages(args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleListConsoleMessages = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     const {
       level,
       limit,
@@ -286,13 +289,11 @@ export async function handleListConsoleMessages(args: unknown): Promise<McpToolR
     }
 
     return successResponse(output);
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+);
 
-export async function handleClearConsoleMessages(_args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleClearConsoleMessages = defineToolHandler(
+  async (_args: unknown): Promise<McpToolResponse> => {
     const { getFirefox } = await import('../index.js');
     const firefox = await getFirefox();
 
@@ -300,10 +301,8 @@ export async function handleClearConsoleMessages(_args: unknown): Promise<McpToo
     firefox.clearConsoleMessages();
 
     return successResponse(`cleared ${count} messages`);
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+);
 
 export const module = defineModule({
   name: 'console',

--- a/src/tools/console.ts
+++ b/src/tools/console.ts
@@ -11,11 +11,7 @@ import {
   truncationFooter,
 } from '../utils/response-helpers.js';
 import { saveOutput } from '../utils/save-output.js';
-<<<<<<< HEAD
-import { defineModule, type ToolDefinition } from './module.js';
-=======
-import { defineModule, defineToolHandler } from './module.js';
->>>>>>> 63301d6 (refactor: use shared errors in network, console, and download tools)
+import { defineModule, defineToolHandler, type ToolDefinition } from './module.js';
 import type { McpToolResponse } from '../types/common.js';
 
 export const listConsoleMessagesTool = {

--- a/src/tools/debugging.ts
+++ b/src/tools/debugging.ts
@@ -1,7 +1,7 @@
 import { successResponse, errorResponse } from '../utils/response-helpers.js';
 import { compareVersions } from '../utils/version.js';
 import { remoteValueToNative } from '../utils/remote-value.js';
-import { defineModule, type ToolDefinition } from './module.js';
+import { defineModule, defineToolHandler, type ToolDefinition } from './module.js';
 import type { McpToolResponse } from '../types/common.js';
 
 const MIN_VERSION = '153';
@@ -117,20 +117,18 @@ export const getLogpointResultsTool = {
 // Handlers
 // ============================================================================
 
-export async function handleEnableDebugger(_args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleEnableDebugger = defineToolHandler(
+  async (_args: unknown): Promise<McpToolResponse> => {
     const { getFirefox } = await import('../index.js');
     const firefox = await getFirefox();
     requireDebuggingSupport(firefox);
     await firefox.sendBiDiCommand('moz:debugging.setDebuggerEnabled', { enabled: true });
     return successResponse('Debugger enabled');
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+);
 
-export async function handleListScripts(_args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleListScripts = defineToolHandler(
+  async (_args: unknown): Promise<McpToolResponse> => {
     const { getFirefox } = await import('../index.js');
     const firefox = await getFirefox();
     requireDebuggingSupport(firefox);
@@ -143,13 +141,11 @@ export async function handleListScripts(_args: unknown): Promise<McpToolResponse
       return successResponse('No scripts found');
     }
     return successResponse(scripts.join('\n'));
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+);
 
-export async function handleGetScriptSource(args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleGetScriptSource = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     const { scriptUrl } = args as { scriptUrl: string };
     const { getFirefox } = await import('../index.js');
     const firefox = await getFirefox();
@@ -160,39 +156,33 @@ export async function handleGetScriptSource(args: unknown): Promise<McpToolRespo
       scriptUrl,
     });
     return successResponse((result as { source: string }).source);
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+);
 
-export async function handleSetLogpoint(args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleSetLogpoint = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     const { url, line, expression } = args as { url: string; line: number; expression: string };
     const { getFirefox } = await import('../index.js');
     const firefox = await getFirefox();
     requireDebuggingSupport(firefox);
     const logpointId = await firefox.setLogpoint(url, line, expression);
     return successResponse(`Logpoint set (id: ${logpointId})`);
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+);
 
-export async function handleRemoveLogpoint(args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleRemoveLogpoint = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     const { logpoint } = args as { logpoint: string };
     const { getFirefox } = await import('../index.js');
     const firefox = await getFirefox();
     requireDebuggingSupport(firefox);
     await firefox.removeLogpoint(logpoint);
     return successResponse('Logpoint removed');
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+);
 
-export async function handleGetLogpointResults(args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleGetLogpointResults = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     const { logpoint } = args as { logpoint: string };
     const { getFirefox } = await import('../index.js');
     const firefox = await getFirefox();
@@ -211,10 +201,8 @@ export async function handleGetLogpointResults(args: unknown): Promise<McpToolRe
       return `[${i + 1}] ${JSON.stringify(remoteValueToNative(r.value))}`;
     });
     return successResponse(lines.join('\n'));
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+);
 
 export const module = defineModule({
   name: 'debugging',

--- a/src/tools/downloads.ts
+++ b/src/tools/downloads.ts
@@ -4,7 +4,7 @@
  */
 
 import { successResponse, errorResponse, jsonResponse } from '../utils/response-helpers.js';
-import { defineModule, type ToolDefinition } from './module.js';
+import { defineModule, defineToolHandler, type ToolDefinition } from './module.js';
 import type { McpToolResponse } from '../types/common.js';
 
 // Tool definitions
@@ -67,84 +67,78 @@ export const setDownloadBehaviorTool = {
 } satisfies ToolDefinition;
 
 // Tool handlers
-export async function handleListDownloads(args: unknown): Promise<McpToolResponse> {
-  try {
-    const {
-      status,
-      urlContains,
-      limit = 50,
-      format = 'text',
-    } = (args ?? {}) as {
-      status?: string;
-      urlContains?: string;
-      limit?: number;
-      format?: string;
-    };
+export const handleListDownloads = defineToolHandler(async function handleListDownloads(
+  args: unknown
+): Promise<McpToolResponse> {
+  const {
+    status,
+    urlContains,
+    limit = 50,
+    format = 'text',
+  } = (args ?? {}) as {
+    status?: string;
+    urlContains?: string;
+    limit?: number;
+    format?: string;
+  };
 
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
-    let downloads = firefox.getDownloads();
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
+  let downloads = firefox.getDownloads();
 
-    if (status) {
-      downloads = downloads.filter((d) => d.status === status);
-    }
-    if (urlContains) {
-      const needle = urlContains.toLowerCase();
-      downloads = downloads.filter((d) => (d.url || '').toLowerCase().includes(needle));
-    }
-
-    downloads = downloads
-      .sort((a, b) => (b.startTimestamp || 0) - (a.startTimestamp || 0))
-      .slice(0, limit);
-
-    if (format === 'json') {
-      return jsonResponse(downloads);
-    }
-
-    if (downloads.length === 0) {
-      return successResponse('No downloads tracked.');
-    }
-
-    const lines = downloads.map((d) => {
-      const where = d.filepath ? ` -> ${d.filepath}` : '';
-      return `[${d.status}] ${d.suggestedFilename || d.url}${where}`;
-    });
-    return successResponse(lines.join('\n'));
-  } catch (error) {
-    return errorResponse(error instanceof Error ? error.message : String(error));
+  if (status) {
+    downloads = downloads.filter((d) => d.status === status);
   }
-}
+  if (urlContains) {
+    const needle = urlContains.toLowerCase();
+    downloads = downloads.filter((d) => (d.url || '').toLowerCase().includes(needle));
+  }
 
-export async function handleClearDownloads(): Promise<McpToolResponse> {
-  try {
+  downloads = downloads
+    .sort((a, b) => (b.startTimestamp || 0) - (a.startTimestamp || 0))
+    .slice(0, limit);
+
+  if (format === 'json') {
+    return jsonResponse(downloads);
+  }
+
+  if (downloads.length === 0) {
+    return successResponse('No downloads tracked.');
+  }
+
+  const lines = downloads.map((d) => {
+    const where = d.filepath ? ` -> ${d.filepath}` : '';
+    return `[${d.status}] ${d.suggestedFilename || d.url}${where}`;
+  });
+  return successResponse(lines.join('\n'));
+});
+
+export const handleClearDownloads = defineToolHandler(
+  async function handleClearDownloads(): Promise<McpToolResponse> {
     const { getFirefox } = await import('../index.js');
     const firefox = await getFirefox();
     firefox.clearDownloads();
     return successResponse('Downloads cleared.');
-  } catch (error) {
-    return errorResponse(error instanceof Error ? error.message : String(error));
   }
-}
+);
 
-export async function handleSetDownloadBehavior(args: unknown): Promise<McpToolResponse> {
-  try {
-    const { behavior } = (args ?? {}) as {
-      behavior?: 'allowed' | 'denied' | 'default';
-    };
+export const handleSetDownloadBehavior = defineToolHandler(async function handleSetDownloadBehavior(
+  args: unknown
+): Promise<McpToolResponse> {
+  const { behavior } = (args ?? {}) as {
+    behavior?: 'allowed' | 'denied' | 'default';
+  };
 
-    if (!behavior) {
-      return errorResponse('behavior is required');
-    }
-
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
-    await firefox.setDownloadBehavior(behavior);
-
-    return successResponse(`Download behavior set to '${behavior}'.`);
-  } catch (error) {
-    return errorResponse(error instanceof Error ? error.message : String(error));
+  if (!behavior) {
+    return errorResponse('behavior is required');
   }
-}
+
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
+  await firefox.setDownloadBehavior(behavior);
+
+  return successResponse(`Download behavior set to '${behavior}'.`);
+});
 
 export const module = defineModule({
   name: 'downloads',

--- a/src/tools/firefox-management.ts
+++ b/src/tools/firefox-management.ts
@@ -5,7 +5,7 @@
 
 import { readFileSync, existsSync, statSync } from 'node:fs';
 import { errorResponse, successResponse } from '../utils/response-helpers.js';
-import { defineModule, type ToolDefinition } from './module.js';
+import { defineModule, defineToolHandler, type ToolDefinition } from './module.js';
 
 // ============================================================================
 // Tool: get_firefox_logs
@@ -37,74 +37,70 @@ export const getFirefoxLogsTool = {
   },
 } satisfies ToolDefinition;
 
-export async function handleGetFirefoxLogs(input: unknown) {
-  try {
-    const {
-      lines = 100,
-      grep,
-      since,
-    } = input as {
-      lines?: number;
-      grep?: string;
-      since?: number;
-    };
+export const handleGetFirefoxLogs = defineToolHandler(async (input: unknown) => {
+  const {
+    lines = 100,
+    grep,
+    since,
+  } = input as {
+    lines?: number;
+    grep?: string;
+    since?: number;
+  };
 
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
-    const logFilePath = firefox.getLogFilePath();
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
+  const logFilePath = firefox.getLogFilePath();
 
-    if (!logFilePath) {
+  if (!logFilePath) {
+    return successResponse(
+      'No output capture configured. Use --env to set environment variables or --output-file to enable output capture.'
+    );
+  }
+
+  if (!existsSync(logFilePath)) {
+    return successResponse(`Output file not found: ${logFilePath}`);
+  }
+
+  // Check file age if 'since' filter is used
+  if (since !== undefined) {
+    const stats = statSync(logFilePath);
+    const ageSeconds = (Date.now() - stats.mtimeMs) / 1000;
+    if (ageSeconds > since) {
       return successResponse(
-        'No output capture configured. Use --env to set environment variables or --output-file to enable output capture.'
+        `Output file is ${Math.floor(ageSeconds)}s old, but only output from last ${since}s was requested. File may not have recent entries.`
       );
     }
-
-    if (!existsSync(logFilePath)) {
-      return successResponse(`Output file not found: ${logFilePath}`);
-    }
-
-    // Check file age if 'since' filter is used
-    if (since !== undefined) {
-      const stats = statSync(logFilePath);
-      const ageSeconds = (Date.now() - stats.mtimeMs) / 1000;
-      if (ageSeconds > since) {
-        return successResponse(
-          `Output file is ${Math.floor(ageSeconds)}s old, but only output from last ${since}s was requested. File may not have recent entries.`
-        );
-      }
-    }
-
-    // Read output file
-    const content = readFileSync(logFilePath, 'utf-8');
-    let allLines = content.split('\n').filter((line) => line.trim().length > 0);
-
-    // Apply grep filter
-    if (grep) {
-      const grepLower = grep.toLowerCase();
-      allLines = allLines.filter((line) => line.toLowerCase().includes(grepLower));
-    }
-
-    // Get last N lines
-    const maxLines = Math.min(lines, 10000);
-    const recentLines = allLines.slice(-maxLines);
-
-    const result = [
-      `Firefox Output File: ${logFilePath}`,
-      `Total lines in file: ${allLines.length}`,
-      grep ? `Lines matching "${grep}": ${allLines.length}` : '',
-      `Showing last ${recentLines.length} lines:`,
-      '',
-      '─'.repeat(80),
-      recentLines.join('\n'),
-    ]
-      .filter(Boolean)
-      .join('\n');
-
-    return successResponse(result);
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+
+  // Read output file
+  const content = readFileSync(logFilePath, 'utf-8');
+  let allLines = content.split('\n').filter((line) => line.trim().length > 0);
+
+  // Apply grep filter
+  if (grep) {
+    const grepLower = grep.toLowerCase();
+    allLines = allLines.filter((line) => line.toLowerCase().includes(grepLower));
+  }
+
+  // Get last N lines
+  const maxLines = Math.min(lines, 10000);
+  const recentLines = allLines.slice(-maxLines);
+
+  const result = [
+    `Firefox Output File: ${logFilePath}`,
+    `Total lines in file: ${allLines.length}`,
+    grep ? `Lines matching "${grep}": ${allLines.length}` : '',
+    `Showing last ${recentLines.length} lines:`,
+    '',
+    '─'.repeat(80),
+    recentLines.join('\n'),
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  return successResponse(result);
+});
 
 // ============================================================================
 // Tool: get_firefox_info
@@ -123,72 +119,68 @@ export const getFirefoxInfoTool = {
   },
 } satisfies ToolDefinition;
 
-export async function handleGetFirefoxInfo(_input: unknown) {
-  try {
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
-    const options = firefox.getOptions();
-    const logFilePath = firefox.getLogFilePath();
-    const version = firefox.getFirefoxVersion();
+export const handleGetFirefoxInfo = defineToolHandler(async (_input: unknown) => {
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
+  const options = firefox.getOptions();
+  const logFilePath = firefox.getLogFilePath();
+  const version = firefox.getFirefoxVersion();
 
-    const info = [];
-    info.push('Firefox Instance Configuration');
-    info.push('');
+  const info = [];
+  info.push('Firefox Instance Configuration');
+  info.push('');
 
-    info.push(`Binary: ${options.firefoxPath ?? 'System Firefox (default)'}`);
-    info.push(`Firefox version: ${version ?? '(unknown)'}`);
-    info.push(`Headless: ${options.headless ? 'Yes' : 'No'}`);
+  info.push(`Binary: ${options.firefoxPath ?? 'System Firefox (default)'}`);
+  info.push(`Firefox version: ${version ?? '(unknown)'}`);
+  info.push(`Headless: ${options.headless ? 'Yes' : 'No'}`);
 
-    if (options.viewport) {
-      info.push(`Viewport: ${options.viewport.width}x${options.viewport.height}`);
-    }
-
-    if (options.profilePath) {
-      info.push(`Profile: ${options.profilePath}`);
-    }
-
-    if (options.startUrl) {
-      info.push(`Start URL: ${options.startUrl}`);
-    }
-
-    if (options.args && options.args.length > 0) {
-      info.push(`Arguments: ${options.args.join(' ')}`);
-    }
-
-    if (options.env && Object.keys(options.env).length > 0) {
-      info.push('');
-      info.push('Environment Variables:');
-      for (const [key, value] of Object.entries(options.env)) {
-        info.push(`  ${key}=${value}`);
-      }
-    }
-
-    if (options.prefs && Object.keys(options.prefs).length > 0) {
-      info.push('');
-      info.push('Preferences:');
-      for (const [key, value] of Object.entries(options.prefs)) {
-        info.push(`  ${key} = ${JSON.stringify(value)}`);
-      }
-    }
-
-    if (logFilePath) {
-      info.push('');
-      info.push(`Output File: ${logFilePath}`);
-      if (existsSync(logFilePath)) {
-        const stats = statSync(logFilePath);
-        const sizeMB = (stats.size / 1024 / 1024).toFixed(2);
-        info.push(`  Size: ${sizeMB} MB`);
-        info.push(`  Last Modified: ${stats.mtime.toISOString()}`);
-      } else {
-        info.push('  (file not created yet)');
-      }
-    }
-
-    return successResponse(info.join('\n'));
-  } catch (error) {
-    return errorResponse(error as Error);
+  if (options.viewport) {
+    info.push(`Viewport: ${options.viewport.width}x${options.viewport.height}`);
   }
-}
+
+  if (options.profilePath) {
+    info.push(`Profile: ${options.profilePath}`);
+  }
+
+  if (options.startUrl) {
+    info.push(`Start URL: ${options.startUrl}`);
+  }
+
+  if (options.args && options.args.length > 0) {
+    info.push(`Arguments: ${options.args.join(' ')}`);
+  }
+
+  if (options.env && Object.keys(options.env).length > 0) {
+    info.push('');
+    info.push('Environment Variables:');
+    for (const [key, value] of Object.entries(options.env)) {
+      info.push(`  ${key}=${value}`);
+    }
+  }
+
+  if (options.prefs && Object.keys(options.prefs).length > 0) {
+    info.push('');
+    info.push('Preferences:');
+    for (const [key, value] of Object.entries(options.prefs)) {
+      info.push(`  ${key} = ${JSON.stringify(value)}`);
+    }
+  }
+
+  if (logFilePath) {
+    info.push('');
+    info.push(`Output File: ${logFilePath}`);
+    if (existsSync(logFilePath)) {
+      const stats = statSync(logFilePath);
+      const sizeMB = (stats.size / 1024 / 1024).toFixed(2);
+      info.push(`  Size: ${sizeMB} MB`);
+      info.push(`  Last Modified: ${stats.mtime.toISOString()}`);
+    } else {
+      info.push('  (file not created yet)');
+    }
+  }
+
+  return successResponse(info.join('\n'));
+});
 
 // ============================================================================
 // Tool: restart_firefox
@@ -241,152 +233,148 @@ export const restartFirefoxTool = {
   },
 } satisfies ToolDefinition;
 
-export async function handleRestartFirefox(input: unknown) {
-  try {
-    const { firefoxPath, profilePath, env, headless, startUrl, prefs } = input as {
-      firefoxPath?: string;
-      profilePath?: string;
-      env?: string[];
-      headless?: boolean;
-      startUrl?: string;
-      prefs?: Record<string, string | number | boolean>;
+export const handleRestartFirefox = defineToolHandler(async (input: unknown) => {
+  const { firefoxPath, profilePath, env, headless, startUrl, prefs } = input as {
+    firefoxPath?: string;
+    profilePath?: string;
+    env?: string[];
+    headless?: boolean;
+    startUrl?: string;
+    prefs?: Record<string, string | number | boolean>;
+  };
+
+  const { args, getFirefoxIfRunning, resetFirefox, setNextLaunchOptions } = await import(
+    '../index.js'
+  );
+
+  // This tool is designed to be robust and never get stuck:
+  // - Handles disconnected Firefox gracefully (resets stale reference)
+  // - Handles close() errors (we're restarting anyway)
+  // - Works both as initial start and restart
+  // - Always leaves system in a clean state for next tool call
+
+  // Parse new environment variables
+  let newEnv: Record<string, string> | undefined;
+  if (env && Array.isArray(env) && env.length > 0) {
+    newEnv = {};
+    for (const envStr of env) {
+      const [key, ...valueParts] = envStr.split('=');
+      if (key && valueParts.length > 0) {
+        newEnv[key] = valueParts.join('=');
+      }
+    }
+  }
+
+  // Check if Firefox is currently running and connected
+  const currentFirefox = getFirefoxIfRunning();
+  const isConnected = currentFirefox ? await currentFirefox.ensureConnected() : false;
+
+  if (currentFirefox && isConnected) {
+    // Firefox is running - restart with new config
+    const currentOptions = currentFirefox.getOptions();
+
+    // Merge prefs: combine existing with new, new takes precedence
+    const mergedPrefs =
+      prefs !== undefined ? { ...(currentOptions.prefs || {}), ...prefs } : currentOptions.prefs;
+
+    // Merge with current options, preferring new values
+    const newOptions = {
+      ...currentOptions,
+      firefoxPath: firefoxPath ?? currentOptions.firefoxPath,
+      profilePath: profilePath ?? currentOptions.profilePath,
+      env: newEnv !== undefined ? newEnv : currentOptions.env,
+      headless: headless !== undefined ? headless : currentOptions.headless,
+      startUrl: startUrl ?? currentOptions.startUrl ?? 'about:blank',
+      prefs: mergedPrefs,
     };
 
-    const { args, getFirefoxIfRunning, resetFirefox, setNextLaunchOptions } = await import(
-      '../index.js'
+    // Set options for next launch
+    setNextLaunchOptions(newOptions);
+
+    // Close current instance
+    await resetFirefox();
+
+    // Prepare change summary
+    const changes = [];
+    if (firefoxPath && firefoxPath !== currentOptions.firefoxPath) {
+      changes.push(`Binary: ${firefoxPath}`);
+    }
+    if (profilePath && profilePath !== currentOptions.profilePath) {
+      changes.push(`Profile: ${profilePath}`);
+    }
+    if (newEnv !== undefined && JSON.stringify(newEnv) !== JSON.stringify(currentOptions.env)) {
+      changes.push(`Environment variables updated:`);
+      for (const [key, value] of Object.entries(newEnv)) {
+        changes.push(`  ${key}=${value}`);
+      }
+    }
+    if (headless !== undefined && headless !== currentOptions.headless) {
+      changes.push(`Headless: ${headless ? 'enabled' : 'disabled'}`);
+    }
+    if (startUrl && startUrl !== currentOptions.startUrl) {
+      changes.push(`Start URL: ${startUrl}`);
+    }
+
+    if (changes.length === 0) {
+      return successResponse(
+        'Firefox closed. Will restart with same configuration on next tool call.'
+      );
+    }
+
+    return successResponse(
+      `Firefox closed. Will restart with new configuration on next tool call:\n${changes.join('\n')}`
     );
-
-    // This tool is designed to be robust and never get stuck:
-    // - Handles disconnected Firefox gracefully (resets stale reference)
-    // - Handles close() errors (we're restarting anyway)
-    // - Works both as initial start and restart
-    // - Always leaves system in a clean state for next tool call
-
-    // Parse new environment variables
-    let newEnv: Record<string, string> | undefined;
-    if (env && Array.isArray(env) && env.length > 0) {
-      newEnv = {};
-      for (const envStr of env) {
-        const [key, ...valueParts] = envStr.split('=');
-        if (key && valueParts.length > 0) {
-          newEnv[key] = valueParts.join('=');
-        }
-      }
-    }
-
-    // Check if Firefox is currently running and connected
-    const currentFirefox = getFirefoxIfRunning();
-    const isConnected = currentFirefox ? await currentFirefox.ensureConnected() : false;
-
-    if (currentFirefox && isConnected) {
-      // Firefox is running - restart with new config
-      const currentOptions = currentFirefox.getOptions();
-
-      // Merge prefs: combine existing with new, new takes precedence
-      const mergedPrefs =
-        prefs !== undefined ? { ...(currentOptions.prefs || {}), ...prefs } : currentOptions.prefs;
-
-      // Merge with current options, preferring new values
-      const newOptions = {
-        ...currentOptions,
-        firefoxPath: firefoxPath ?? currentOptions.firefoxPath,
-        profilePath: profilePath ?? currentOptions.profilePath,
-        env: newEnv !== undefined ? newEnv : currentOptions.env,
-        headless: headless !== undefined ? headless : currentOptions.headless,
-        startUrl: startUrl ?? currentOptions.startUrl ?? 'about:blank',
-        prefs: mergedPrefs,
-      };
-
-      // Set options for next launch
-      setNextLaunchOptions(newOptions);
-
-      // Close current instance
+  } else {
+    // Firefox not running (or disconnected) - configure for first start
+    if (currentFirefox) {
+      // Had a stale disconnected reference, clean it up
       await resetFirefox();
+    }
 
-      // Prepare change summary
-      const changes = [];
-      if (firefoxPath && firefoxPath !== currentOptions.firefoxPath) {
-        changes.push(`Binary: ${firefoxPath}`);
-      }
-      if (profilePath && profilePath !== currentOptions.profilePath) {
-        changes.push(`Profile: ${profilePath}`);
-      }
-      if (newEnv !== undefined && JSON.stringify(newEnv) !== JSON.stringify(currentOptions.env)) {
-        changes.push(`Environment variables updated:`);
-        for (const [key, value] of Object.entries(newEnv)) {
-          changes.push(`  ${key}=${value}`);
-        }
-      }
-      if (headless !== undefined && headless !== currentOptions.headless) {
-        changes.push(`Headless: ${headless ? 'enabled' : 'disabled'}`);
-      }
-      if (startUrl && startUrl !== currentOptions.startUrl) {
-        changes.push(`Start URL: ${startUrl}`);
-      }
+    // Use provided firefoxPath, or fall back to CLI args if available
+    const resolvedFirefoxPath = firefoxPath ?? args.firefoxPath ?? undefined;
 
-      if (changes.length === 0) {
-        return successResponse(
-          'Firefox closed. Will restart with same configuration on next tool call.'
-        );
-      }
-
-      return successResponse(
-        `Firefox closed. Will restart with new configuration on next tool call:\n${changes.join('\n')}`
-      );
-    } else {
-      // Firefox not running (or disconnected) - configure for first start
-      if (currentFirefox) {
-        // Had a stale disconnected reference, clean it up
-        await resetFirefox();
-      }
-
-      // Use provided firefoxPath, or fall back to CLI args if available
-      const resolvedFirefoxPath = firefoxPath ?? args.firefoxPath ?? undefined;
-
-      if (!resolvedFirefoxPath) {
-        return errorResponse(
-          new Error(
-            'Firefox is not running and no firefoxPath provided. Please specify firefoxPath to start Firefox.'
-          )
-        );
-      }
-
-      const newOptions = {
-        firefoxPath: resolvedFirefoxPath,
-        profilePath: profilePath ?? args.profilePath ?? undefined,
-        env: newEnv,
-        headless: headless ?? false,
-        startUrl: startUrl ?? 'about:blank',
-      };
-
-      setNextLaunchOptions(newOptions);
-
-      const config = [`Binary: ${resolvedFirefoxPath}`];
-      const resolvedProfilePath = profilePath ?? args.profilePath;
-      if (resolvedProfilePath) {
-        config.push(`Profile: ${resolvedProfilePath}`);
-      }
-      if (newEnv) {
-        config.push('Environment variables:');
-        for (const [key, value] of Object.entries(newEnv)) {
-          config.push(`  ${key}=${value}`);
-        }
-      }
-      if (headless) {
-        config.push('Headless: enabled');
-      }
-      if (startUrl) {
-        config.push(`Start URL: ${startUrl}`);
-      }
-
-      return successResponse(
-        `Firefox configured. Will start on next tool call:\n${config.join('\n')}`
+    if (!resolvedFirefoxPath) {
+      return errorResponse(
+        new Error(
+          'Firefox is not running and no firefoxPath provided. Please specify firefoxPath to start Firefox.'
+        )
       );
     }
-  } catch (error) {
-    return errorResponse(error as Error);
+
+    const newOptions = {
+      firefoxPath: resolvedFirefoxPath,
+      profilePath: profilePath ?? args.profilePath ?? undefined,
+      env: newEnv,
+      headless: headless ?? false,
+      startUrl: startUrl ?? 'about:blank',
+    };
+
+    setNextLaunchOptions(newOptions);
+
+    const config = [`Binary: ${resolvedFirefoxPath}`];
+    const resolvedProfilePath = profilePath ?? args.profilePath;
+    if (resolvedProfilePath) {
+      config.push(`Profile: ${resolvedProfilePath}`);
+    }
+    if (newEnv) {
+      config.push('Environment variables:');
+      for (const [key, value] of Object.entries(newEnv)) {
+        config.push(`  ${key}=${value}`);
+      }
+    }
+    if (headless) {
+      config.push('Headless: enabled');
+    }
+    if (startUrl) {
+      config.push(`Start URL: ${startUrl}`);
+    }
+
+    return successResponse(
+      `Firefox configured. Will start on next tool call:\n${config.join('\n')}`
+    );
   }
-}
+});
 
 export const module = defineModule({
   name: 'management',

--- a/src/tools/firefox-prefs.ts
+++ b/src/tools/firefox-prefs.ts
@@ -4,9 +4,9 @@
  * Requires MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1
  */
 
-import { successResponse, errorResponse } from '../utils/response-helpers.js';
+import { successResponse } from '../utils/response-helpers.js';
 import { generatePrefScript } from '../firefox/pref-utils.js';
-import { defineModule, type ToolDefinition } from './module.js';
+import { defineModule, defineToolHandler, type ToolDefinition } from './module.js';
 import type { McpToolResponse } from '../types/common.js';
 
 // ============================================================================
@@ -36,92 +36,92 @@ export const setFirefoxPrefsTool = {
   },
 } satisfies ToolDefinition;
 
-export async function handleSetFirefoxPrefs(args: unknown): Promise<McpToolResponse> {
-  try {
-    const { prefs } = args as { prefs: Record<string, string | number | boolean> };
-
-    if (!prefs || typeof prefs !== 'object') {
-      throw new Error('prefs parameter is required and must be an object');
-    }
-
-    const prefEntries = Object.entries(prefs);
-    if (prefEntries.length === 0) {
-      return successResponse('No preferences to set');
-    }
-
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
-
-    // Get privileged ("chrome") contexts
-    const result = await firefox.sendBiDiCommand('browsingContext.getTree', {
-      'moz:scope': 'chrome',
-    });
-
-    const contexts = result.contexts || [];
-    if (contexts.length === 0) {
-      throw new Error(
-        'No privileged contexts available. Ensure MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 is set.'
-      );
-    }
-
-    const driver = firefox.getDriver();
-    const chromeContextId = contexts[0].context;
-
-    // Remember current context
-    const originalContextId = firefox.getCurrentContextId();
-
+export const handleSetFirefoxPrefs = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     try {
-      // Switch to chrome context
-      await driver.switchTo().window(chromeContextId);
-      await driver.setContext('chrome');
+      const { prefs } = args as { prefs: Record<string, string | number | boolean> };
 
-      const results: string[] = [];
-      const errors: string[] = [];
-
-      // Set each preference
-      for (const [name, value] of prefEntries) {
-        try {
-          const script = generatePrefScript(name, value);
-          await driver.executeScript(script);
-          results.push(`  ${name} = ${JSON.stringify(value)}`);
-        } catch (error) {
-          errors.push(`  ${name}: ${error instanceof Error ? error.message : String(error)}`);
-        }
+      if (!prefs || typeof prefs !== 'object') {
+        throw new Error('prefs parameter is required and must be an object');
       }
 
-      const output: string[] = [];
-      if (results.length > 0) {
-        output.push(`Set ${results.length} preference(s):`);
-        output.push(...results);
-      }
-      if (errors.length > 0) {
-        output.push(`\nFailed to set ${errors.length} preference(s):`);
-        output.push(...errors);
+      const prefEntries = Object.entries(prefs);
+      if (prefEntries.length === 0) {
+        return successResponse('No preferences to set');
       }
 
-      return successResponse(output.join('\n'));
-    } finally {
-      // Restore previous context (skip if already on the right chrome context)
+      const { getFirefox } = await import('../index.js');
+      const firefox = await getFirefox();
+
+      // Get privileged ("chrome") contexts
+      const result = await firefox.sendBiDiCommand('browsingContext.getTree', {
+        'moz:scope': 'chrome',
+      });
+
+      const contexts = result.contexts || [];
+      if (contexts.length === 0) {
+        throw new Error(
+          'No privileged contexts available. Ensure MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 is set.'
+        );
+      }
+
+      const driver = firefox.getDriver();
+      const chromeContextId = contexts[0].context;
+
+      // Remember current context
+      const originalContextId = firefox.getCurrentContextId();
+
       try {
-        if (originalContextId && originalContextId !== chromeContextId) {
-          await driver.setContext('content');
-          await driver.switchTo().window(originalContextId);
+        // Switch to chrome context
+        await driver.switchTo().window(chromeContextId);
+        await driver.setContext('chrome');
+
+        const results: string[] = [];
+        const errors: string[] = [];
+
+        // Set each preference
+        for (const [name, value] of prefEntries) {
+          try {
+            const script = generatePrefScript(name, value);
+            await driver.executeScript(script);
+            results.push(`  ${name} = ${JSON.stringify(value)}`);
+          } catch (error) {
+            errors.push(`  ${name}: ${error instanceof Error ? error.message : String(error)}`);
+          }
         }
-      } catch {
-        // Ignore errors restoring context
+
+        const output: string[] = [];
+        if (results.length > 0) {
+          output.push(`Set ${results.length} preference(s):`);
+          output.push(...results);
+        }
+        if (errors.length > 0) {
+          output.push(`\nFailed to set ${errors.length} preference(s):`);
+          output.push(...errors);
+        }
+
+        return successResponse(output.join('\n'));
+      } finally {
+        // Restore previous context (skip if already on the right chrome context)
+        try {
+          if (originalContextId && originalContextId !== chromeContextId) {
+            await driver.setContext('content');
+            await driver.switchTo().window(originalContextId);
+          }
+        } catch {
+          // Ignore errors restoring context
+        }
       }
-    }
-  } catch (error) {
-    if (error instanceof Error && error.message.includes('UnsupportedOperationError')) {
-      return errorResponse(
-        new Error(
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('UnsupportedOperationError')) {
+        throw new Error(
           'Chrome context access not enabled. Set MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 environment variable and restart Firefox.'
-        )
-      );
+        );
+      }
+      throw error;
     }
-    return errorResponse(error as Error);
   }
-}
+);
 
 // ============================================================================
 // Tool: get_firefox_prefs
@@ -147,48 +147,49 @@ export const getFirefoxPrefsTool = {
   },
 } satisfies ToolDefinition;
 
-export async function handleGetFirefoxPrefs(args: unknown): Promise<McpToolResponse> {
-  try {
-    const { names } = args as { names: string[] };
-
-    if (!names || !Array.isArray(names) || names.length === 0) {
-      throw new Error('names parameter is required and must be a non-empty array');
-    }
-
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
-
-    // Get privileged ("chrome") contexts
-    const result = await firefox.sendBiDiCommand('browsingContext.getTree', {
-      'moz:scope': 'chrome',
-    });
-
-    const contexts = result.contexts || [];
-    if (contexts.length === 0) {
-      throw new Error(
-        'No privileged contexts available. Ensure MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 is set.'
-      );
-    }
-
-    const driver = firefox.getDriver();
-    const chromeContextId = contexts[0].context;
-
-    // Remember current context
-    const originalContextId = firefox.getCurrentContextId();
-
+export const handleGetFirefoxPrefs = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     try {
-      // Switch to chrome context
-      await driver.switchTo().window(chromeContextId);
-      await driver.setContext('chrome');
+      const { names } = args as { names: string[] };
 
-      const results: string[] = [];
-      const errors: string[] = [];
+      if (!names || !Array.isArray(names) || names.length === 0) {
+        throw new Error('names parameter is required and must be a non-empty array');
+      }
 
-      // Read each preference
-      for (const name of names) {
-        try {
-          // Use getPrefType to determine how to read the pref
-          const script = `
+      const { getFirefox } = await import('../index.js');
+      const firefox = await getFirefox();
+
+      // Get privileged ("chrome") contexts
+      const result = await firefox.sendBiDiCommand('browsingContext.getTree', {
+        'moz:scope': 'chrome',
+      });
+
+      const contexts = result.contexts || [];
+      if (contexts.length === 0) {
+        throw new Error(
+          'No privileged contexts available. Ensure MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 is set.'
+        );
+      }
+
+      const driver = firefox.getDriver();
+      const chromeContextId = contexts[0].context;
+
+      // Remember current context
+      const originalContextId = firefox.getCurrentContextId();
+
+      try {
+        // Switch to chrome context
+        await driver.switchTo().window(chromeContextId);
+        await driver.setContext('chrome');
+
+        const results: string[] = [];
+        const errors: string[] = [];
+
+        // Read each preference
+        for (const name of names) {
+          try {
+            // Use getPrefType to determine how to read the pref
+            const script = `
             (function() {
               const type = Services.prefs.getPrefType(${JSON.stringify(name)});
               if (type === Services.prefs.PREF_INVALID) {
@@ -202,54 +203,53 @@ export async function handleGetFirefoxPrefs(args: unknown): Promise<McpToolRespo
               }
             })()
           `;
-          const prefResult = (await driver.executeScript(`return ${script}`)) as {
-            exists: boolean;
-            value?: unknown;
-          };
+            const prefResult = (await driver.executeScript(`return ${script}`)) as {
+              exists: boolean;
+              value?: unknown;
+            };
 
-          if (prefResult.exists) {
-            results.push(`  ${name} = ${JSON.stringify(prefResult.value)}`);
-          } else {
-            results.push(`  ${name} = (not set)`);
+            if (prefResult.exists) {
+              results.push(`  ${name} = ${JSON.stringify(prefResult.value)}`);
+            } else {
+              results.push(`  ${name} = (not set)`);
+            }
+          } catch (error) {
+            errors.push(`  ${name}: ${error instanceof Error ? error.message : String(error)}`);
           }
-        } catch (error) {
-          errors.push(`  ${name}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+
+        const output: string[] = [];
+        if (results.length > 0) {
+          output.push(`Firefox Preferences:`);
+          output.push(...results);
+        }
+        if (errors.length > 0) {
+          output.push(`\nFailed to read ${errors.length} preference(s):`);
+          output.push(...errors);
+        }
+
+        return successResponse(output.join('\n'));
+      } finally {
+        // Restore previous context (skip if already on the right chrome context)
+        try {
+          if (originalContextId && originalContextId !== chromeContextId) {
+            await driver.setContext('content');
+            await driver.switchTo().window(originalContextId);
+          }
+        } catch {
+          // Ignore errors restoring context
         }
       }
-
-      const output: string[] = [];
-      if (results.length > 0) {
-        output.push(`Firefox Preferences:`);
-        output.push(...results);
-      }
-      if (errors.length > 0) {
-        output.push(`\nFailed to read ${errors.length} preference(s):`);
-        output.push(...errors);
-      }
-
-      return successResponse(output.join('\n'));
-    } finally {
-      // Restore previous context (skip if already on the right chrome context)
-      try {
-        if (originalContextId && originalContextId !== chromeContextId) {
-          await driver.setContext('content');
-          await driver.switchTo().window(originalContextId);
-        }
-      } catch {
-        // Ignore errors restoring context
-      }
-    }
-  } catch (error) {
-    if (error instanceof Error && error.message.includes('UnsupportedOperationError')) {
-      return errorResponse(
-        new Error(
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('UnsupportedOperationError')) {
+        throw new Error(
           'Chrome context access not enabled. Set MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 environment variable and restart Firefox.'
-        )
-      );
+        );
+      }
+      throw error;
     }
-    return errorResponse(error as Error);
   }
-}
+);
 
 export const module = defineModule({
   name: 'prefs',

--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -3,9 +3,9 @@
  * Require valid UIDs from take_snapshot
  */
 
-import { successResponse, errorResponse } from '../utils/response-helpers.js';
+import { successResponse } from '../utils/response-helpers.js';
 import { handleUidError } from '../utils/uid-helpers.js';
-import { defineModule, type ToolDefinition } from './module.js';
+import { defineModule, defineToolHandler, type ToolDefinition } from './module.js';
 import type { McpToolResponse } from '../types/common.js';
 
 // Tool definitions
@@ -148,184 +148,172 @@ export const uploadFileByUidTool = {
 } satisfies ToolDefinition;
 
 // Handlers
-export async function handleClickByUid(args: unknown): Promise<McpToolResponse> {
+export const handleClickByUid = defineToolHandler(async function handleClickByUid(
+  args: unknown
+): Promise<McpToolResponse> {
+  const { uid, dblClick } = args as { uid: string; dblClick?: boolean };
+
+  if (!uid || typeof uid !== 'string') {
+    throw new Error('uid parameter is required and must be a string');
+  }
+
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
+
   try {
-    const { uid, dblClick } = args as { uid: string; dblClick?: boolean };
+    await firefox.clickByUid(uid, dblClick);
+    return successResponse(`${dblClick ? 'dblclick' : 'click'} ${uid}`);
+  } catch (error) {
+    throw handleUidError(error as Error, uid);
+  }
+});
 
-    if (!uid || typeof uid !== 'string') {
-      throw new Error('uid parameter is required and must be a string');
+export const handleHoverByUid = defineToolHandler(async function handleHoverByUid(
+  args: unknown
+): Promise<McpToolResponse> {
+  const { uid } = args as { uid: string };
+
+  if (!uid || typeof uid !== 'string') {
+    throw new Error('uid parameter is required and must be a string');
+  }
+
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
+
+  try {
+    await firefox.hoverByUid(uid);
+    return successResponse(`hover ${uid}`);
+  } catch (error) {
+    throw handleUidError(error as Error, uid);
+  }
+});
+
+export const handleFillByUid = defineToolHandler(async function handleFillByUid(
+  args: unknown
+): Promise<McpToolResponse> {
+  const { uid, value } = args as { uid: string; value: string };
+
+  if (!uid || typeof uid !== 'string') {
+    throw new Error('uid parameter is required and must be a string');
+  }
+
+  if (value === undefined || typeof value !== 'string') {
+    throw new Error('value parameter is required and must be a string');
+  }
+
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
+
+  try {
+    await firefox.fillByUid(uid, value);
+    return successResponse(`fill ${uid}`);
+  } catch (error) {
+    throw handleUidError(error as Error, uid);
+  }
+});
+
+export const handleDragByUidToUid = defineToolHandler(async function handleDragByUidToUid(
+  args: unknown
+): Promise<McpToolResponse> {
+  const { fromUid, toUid } = args as { fromUid: string; toUid: string };
+
+  if (!fromUid || typeof fromUid !== 'string') {
+    throw new Error('fromUid parameter is required and must be a string');
+  }
+
+  if (!toUid || typeof toUid !== 'string') {
+    throw new Error('toUid parameter is required and must be a string');
+  }
+
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
+
+  try {
+    await firefox.dragByUidToUid(fromUid, toUid);
+    return successResponse(`drag ${fromUid}→${toUid}`);
+  } catch (error) {
+    // Check both UIDs for staleness
+    const errorMsg = (error as Error).message;
+    if (errorMsg.includes('stale') || errorMsg.includes('Snapshot') || errorMsg.includes('UID')) {
+      throw new Error(`UIDs stale/invalid. Call take_snapshot first.`);
     }
+    throw error;
+  }
+});
 
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
+export const handleFillFormByUid = defineToolHandler(async function handleFillFormByUid(
+  args: unknown
+): Promise<McpToolResponse> {
+  const { elements } = args as { elements: Array<{ uid: string; value: string }> };
 
-    try {
-      await firefox.clickByUid(uid, dblClick);
-      return successResponse(`${dblClick ? 'dblclick' : 'click'} ${uid}`);
-    } catch (error) {
+  if (!elements || !Array.isArray(elements) || elements.length === 0) {
+    throw new Error('elements parameter is required and must be a non-empty array');
+  }
+
+  // Validate all elements
+  for (const el of elements) {
+    if (!el.uid || typeof el.uid !== 'string') {
+      throw new Error(`Invalid element: uid is required and must be a string`);
+    }
+    if (el.value === undefined || typeof el.value !== 'string') {
+      throw new Error(`Invalid element for uid "${el.uid}": value must be a string`);
+    }
+  }
+
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
+
+  try {
+    await firefox.fillFormByUid(elements);
+    return successResponse(`filled ${elements.length} fields`);
+  } catch (error) {
+    const errorMsg = (error as Error).message;
+    if (errorMsg.includes('stale') || errorMsg.includes('Snapshot') || errorMsg.includes('UID')) {
+      throw new Error(`UIDs stale/invalid. Call take_snapshot first.`);
+    }
+    throw error;
+  }
+});
+
+export const handleUploadFileByUid = defineToolHandler(async function handleUploadFileByUid(
+  args: unknown
+): Promise<McpToolResponse> {
+  const { uid, filePath } = args as { uid: string; filePath: string };
+
+  if (!uid || typeof uid !== 'string') {
+    throw new Error('uid parameter is required and must be a string');
+  }
+
+  if (!filePath || typeof filePath !== 'string') {
+    throw new Error('filePath parameter is required and must be a string');
+  }
+
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
+
+  try {
+    await firefox.uploadFileByUid(uid, filePath);
+    return successResponse(`upload ${uid}`);
+  } catch (error) {
+    const errorMsg = (error as Error).message;
+
+    // Check for UID staleness
+    if (errorMsg.includes('stale') || errorMsg.includes('Snapshot') || errorMsg.includes('UID')) {
       throw handleUidError(error as Error, uid);
     }
-  } catch (error) {
-    return errorResponse(error as Error);
+
+    // Check for file input specific errors
+    if (errorMsg.includes('not a file input') || errorMsg.includes('type="file"')) {
+      throw new Error(`${uid} is not a file input`);
+    }
+
+    if (errorMsg.includes('hidden') || errorMsg.includes('not visible')) {
+      throw new Error(`${uid} is hidden/not interactable`);
+    }
+
+    throw error;
   }
-}
-
-export async function handleHoverByUid(args: unknown): Promise<McpToolResponse> {
-  try {
-    const { uid } = args as { uid: string };
-
-    if (!uid || typeof uid !== 'string') {
-      throw new Error('uid parameter is required and must be a string');
-    }
-
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
-
-    try {
-      await firefox.hoverByUid(uid);
-      return successResponse(`hover ${uid}`);
-    } catch (error) {
-      throw handleUidError(error as Error, uid);
-    }
-  } catch (error) {
-    return errorResponse(error as Error);
-  }
-}
-
-export async function handleFillByUid(args: unknown): Promise<McpToolResponse> {
-  try {
-    const { uid, value } = args as { uid: string; value: string };
-
-    if (!uid || typeof uid !== 'string') {
-      throw new Error('uid parameter is required and must be a string');
-    }
-
-    if (value === undefined || typeof value !== 'string') {
-      throw new Error('value parameter is required and must be a string');
-    }
-
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
-
-    try {
-      await firefox.fillByUid(uid, value);
-      return successResponse(`fill ${uid}`);
-    } catch (error) {
-      throw handleUidError(error as Error, uid);
-    }
-  } catch (error) {
-    return errorResponse(error as Error);
-  }
-}
-
-export async function handleDragByUidToUid(args: unknown): Promise<McpToolResponse> {
-  try {
-    const { fromUid, toUid } = args as { fromUid: string; toUid: string };
-
-    if (!fromUid || typeof fromUid !== 'string') {
-      throw new Error('fromUid parameter is required and must be a string');
-    }
-
-    if (!toUid || typeof toUid !== 'string') {
-      throw new Error('toUid parameter is required and must be a string');
-    }
-
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
-
-    try {
-      await firefox.dragByUidToUid(fromUid, toUid);
-      return successResponse(`drag ${fromUid}→${toUid}`);
-    } catch (error) {
-      // Check both UIDs for staleness
-      const errorMsg = (error as Error).message;
-      if (errorMsg.includes('stale') || errorMsg.includes('Snapshot') || errorMsg.includes('UID')) {
-        throw new Error(`UIDs stale/invalid. Call take_snapshot first.`);
-      }
-      throw error;
-    }
-  } catch (error) {
-    return errorResponse(error as Error);
-  }
-}
-
-export async function handleFillFormByUid(args: unknown): Promise<McpToolResponse> {
-  try {
-    const { elements } = args as { elements: Array<{ uid: string; value: string }> };
-
-    if (!elements || !Array.isArray(elements) || elements.length === 0) {
-      throw new Error('elements parameter is required and must be a non-empty array');
-    }
-
-    // Validate all elements
-    for (const el of elements) {
-      if (!el.uid || typeof el.uid !== 'string') {
-        throw new Error(`Invalid element: uid is required and must be a string`);
-      }
-      if (el.value === undefined || typeof el.value !== 'string') {
-        throw new Error(`Invalid element for uid "${el.uid}": value must be a string`);
-      }
-    }
-
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
-
-    try {
-      await firefox.fillFormByUid(elements);
-      return successResponse(`filled ${elements.length} fields`);
-    } catch (error) {
-      const errorMsg = (error as Error).message;
-      if (errorMsg.includes('stale') || errorMsg.includes('Snapshot') || errorMsg.includes('UID')) {
-        throw new Error(`UIDs stale/invalid. Call take_snapshot first.`);
-      }
-      throw error;
-    }
-  } catch (error) {
-    return errorResponse(error as Error);
-  }
-}
-
-export async function handleUploadFileByUid(args: unknown): Promise<McpToolResponse> {
-  try {
-    const { uid, filePath } = args as { uid: string; filePath: string };
-
-    if (!uid || typeof uid !== 'string') {
-      throw new Error('uid parameter is required and must be a string');
-    }
-
-    if (!filePath || typeof filePath !== 'string') {
-      throw new Error('filePath parameter is required and must be a string');
-    }
-
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
-
-    try {
-      await firefox.uploadFileByUid(uid, filePath);
-      return successResponse(`upload ${uid}`);
-    } catch (error) {
-      const errorMsg = (error as Error).message;
-
-      // Check for UID staleness
-      if (errorMsg.includes('stale') || errorMsg.includes('Snapshot') || errorMsg.includes('UID')) {
-        throw handleUidError(error as Error, uid);
-      }
-
-      // Check for file input specific errors
-      if (errorMsg.includes('not a file input') || errorMsg.includes('type="file"')) {
-        throw new Error(`${uid} is not a file input`);
-      }
-
-      if (errorMsg.includes('hidden') || errorMsg.includes('not visible')) {
-        throw new Error(`${uid} is hidden/not interactable`);
-      }
-
-      throw error;
-    }
-  } catch (error) {
-    return errorResponse(error as Error);
-  }
-}
+});
 
 export const module = defineModule({
   name: 'input',

--- a/src/tools/module.ts
+++ b/src/tools/module.ts
@@ -7,6 +7,7 @@
  */
 
 import type { McpToolResponse } from '../types/common.js';
+import { errorResponse } from '../utils/response-helpers.js';
 
 export type JsonSchemaType = 'array' | 'boolean' | 'integer' | 'number' | 'object' | 'string';
 
@@ -61,6 +62,18 @@ export interface ModuleConfig {
   privileged?: boolean;
   /** Each entry pairs a tool definition with its handler. */
   tools: Array<[ToolDefinition, ToolHandler]>;
+}
+
+export function defineToolHandler<TArgs extends unknown[]>(
+  handler: (...args: TArgs) => Promise<McpToolResponse>
+): (...args: TArgs) => Promise<McpToolResponse> {
+  return async (...args: TArgs): Promise<McpToolResponse> => {
+    try {
+      return await handler(...args);
+    } catch (error) {
+      return errorResponse(error instanceof Error ? error : String(error));
+    }
+  };
 }
 
 export function defineModule(config: ModuleConfig): ToolModule {

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -14,7 +14,7 @@ import {
   TOKEN_LIMITS,
 } from '../utils/response-helpers.js';
 import { saveOutput } from '../utils/save-output.js';
-import { defineModule, type ToolDefinition } from './module.js';
+import { defineModule, defineToolHandler, type ToolDefinition } from './module.js';
 import type { McpToolResponse } from '../types/common.js';
 import type { NetworkBodyResult } from '../firefox/events/network.js';
 
@@ -204,8 +204,8 @@ function renderBodyForFile(result: NetworkBodyResult): {
 }
 
 // Tool handlers
-export async function handleListNetworkRequests(args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleListNetworkRequests = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     const {
       limit,
       sinceMs,
@@ -448,13 +448,11 @@ export async function handleListNetworkRequests(args: unknown): Promise<McpToolR
           moreFooter
       );
     }
-  } catch (error) {
-    return errorResponse(error instanceof Error ? error : new Error(String(error)));
   }
-}
+);
 
-export async function handleGetNetworkRequest(args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleGetNetworkRequest = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     const { id, url, format, saveTo, preview } = args as {
       id?: string;
       url?: string;
@@ -575,10 +573,8 @@ export async function handleGetNetworkRequest(args: unknown): Promise<McpToolRes
     }
 
     return successResponse(JSON.stringify(details, null, 2));
-  } catch (error) {
-    return errorResponse(error instanceof Error ? error : new Error(String(error)));
   }
-}
+);
 
 export const module = defineModule({
   name: 'network',

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -218,12 +218,12 @@ export const handleNewPage = defineToolHandler(async function handleNewPage(
     throw new Error('url parameter is required and must be a string');
   }
 
+  const waitFor = parseWait(wait);
+
   const { getFirefox } = await import('../index.js');
   const firefox = await getFirefox();
 
-  const newIdx = await firefox.createNewPage(url);
-
-  const waitFor = parseWait(wait);
+  const newIdx = await firefox.createNewPage(url, waitFor);
 
   return successResponse(`new page [${newIdx}] → ${url}${waitSuffix(waitFor)}`);
 });
@@ -237,6 +237,8 @@ export const handleNavigatePage = defineToolHandler(async function handleNavigat
     throw new Error('url parameter is required and must be a string');
   }
 
+  const waitFor = parseWait(wait);
+
   const { getFirefox } = await import('../index.js');
   const firefox = await getFirefox();
 
@@ -245,11 +247,6 @@ export const handleNavigatePage = defineToolHandler(async function handleNavigat
   const tabs = firefox.getTabs();
   const selectedIdx = firefox.getSelectedTabIdx();
   const page = tabs[selectedIdx];
-
-  const waitFor = parseWait(wait);
-
-  // Refresh tabs to get latest list
-  await firefox.refreshTabs();
 
   if (!page) {
     throw new Error('No page selected');

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -2,15 +2,15 @@
  * Page navigation and management tools for MCP
  */
 
-import {
-  successResponse,
-  errorResponse,
-  previewExcerpt,
-  truncationFooter,
-} from '../utils/response-helpers.js';
+import { successResponse, previewExcerpt, truncationFooter } from '../utils/response-helpers.js';
 import { saveOutput } from '../utils/save-output.js';
 import { READINESS_STATES, isReadinessState, type ReadinessState } from '../firefox/pages.js';
-import { defineModule, type JsonSchemaProperty, type ToolDefinition } from './module.js';
+import {
+  defineModule,
+  defineToolHandler,
+  type JsonSchemaProperty,
+  type ToolDefinition,
+} from './module.js';
 import type { McpToolResponse } from '../types/common.js';
 
 const DEFAULT_MAX_CONTENT_CHARS = 20_000;
@@ -196,152 +196,145 @@ function formatPageList(
 }
 
 // Handlers
-export async function handleListPages(_args: unknown): Promise<McpToolResponse> {
-  try {
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
+export const handleListPages = defineToolHandler(async function handleListPages(
+  _args: unknown
+): Promise<McpToolResponse> {
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
 
-    await firefox.refreshTabs();
-    const tabs = firefox.getTabs();
-    const selectedIdx = firefox.getSelectedTabIdx();
+  await firefox.refreshTabs();
+  const tabs = firefox.getTabs();
+  const selectedIdx = firefox.getSelectedTabIdx();
 
-    return successResponse(formatPageList(tabs, selectedIdx));
-  } catch (error) {
-    return errorResponse(error as Error);
+  return successResponse(formatPageList(tabs, selectedIdx));
+});
+
+export const handleNewPage = defineToolHandler(async function handleNewPage(
+  args: unknown
+): Promise<McpToolResponse> {
+  const { url, wait } = args as { url: string; wait?: unknown };
+
+  if (!url || typeof url !== 'string') {
+    throw new Error('url parameter is required and must be a string');
   }
-}
 
-export async function handleNewPage(args: unknown): Promise<McpToolResponse> {
-  try {
-    const { url, wait } = args as { url: string; wait?: unknown };
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
 
-    if (!url || typeof url !== 'string') {
-      throw new Error('url parameter is required and must be a string');
-    }
+  const newIdx = await firefox.createNewPage(url);
 
-    const waitFor = parseWait(wait);
+  const waitFor = parseWait(wait);
 
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
+  return successResponse(`new page [${newIdx}] → ${url}${waitSuffix(waitFor)}`);
+});
 
-    const newIdx = await firefox.createNewPage(url, waitFor);
+export const handleNavigatePage = defineToolHandler(async function handleNavigatePage(
+  args: unknown
+): Promise<McpToolResponse> {
+  const { url, wait } = args as { url: string; wait?: unknown };
 
-    return successResponse(`new page [${newIdx}] → ${url}${waitSuffix(waitFor)}`);
-  } catch (error) {
-    return errorResponse(error as Error);
+  if (!url || typeof url !== 'string') {
+    throw new Error('url parameter is required and must be a string');
   }
-}
 
-export async function handleNavigatePage(args: unknown): Promise<McpToolResponse> {
-  try {
-    const { url, wait } = args as { url: string; wait?: unknown };
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
 
-    if (!url || typeof url !== 'string') {
-      throw new Error('url parameter is required and must be a string');
-    }
+  // Refresh tabs to get latest list
+  await firefox.refreshTabs();
+  const tabs = firefox.getTabs();
+  const selectedIdx = firefox.getSelectedTabIdx();
+  const page = tabs[selectedIdx];
 
-    const waitFor = parseWait(wait);
+  const waitFor = parseWait(wait);
 
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
+  // Refresh tabs to get latest list
+  await firefox.refreshTabs();
 
-    // Refresh tabs to get latest list
-    await firefox.refreshTabs();
-    const tabs = firefox.getTabs();
-    const selectedIdx = firefox.getSelectedTabIdx();
-    const page = tabs[selectedIdx];
-
-    if (!page) {
-      throw new Error('No page selected');
-    }
-
-    await firefox.navigate(url, waitFor);
-
-    return successResponse(`[${selectedIdx}] → ${url}${waitSuffix(waitFor)}`);
-  } catch (error) {
-    return errorResponse(error as Error);
+  if (!page) {
+    throw new Error('No page selected');
   }
-}
 
-export async function handleSelectPage(args: unknown): Promise<McpToolResponse> {
-  try {
-    const { pageIdx, url, title } = args as { pageIdx?: number; url?: string; title?: string };
+  await firefox.navigate(url, waitFor);
 
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
+  return successResponse(`[${selectedIdx}] → ${url}${waitSuffix(waitFor)}`);
+});
 
-    // Refresh tabs to get latest list
-    await firefox.refreshTabs();
-    const tabs = firefox.getTabs();
+export const handleSelectPage = defineToolHandler(async function handleSelectPage(
+  args: unknown
+): Promise<McpToolResponse> {
+  const { pageIdx, url, title } = args as { pageIdx?: number; url?: string; title?: string };
 
-    let selectedIdx: number;
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
 
-    // Priority 1: Select by index
-    if (typeof pageIdx === 'number') {
-      selectedIdx = pageIdx;
-    }
-    // Priority 2: Select by URL pattern
-    else if (url && typeof url === 'string') {
-      const urlLower = url.toLowerCase();
-      const foundIdx = tabs.findIndex((tab) => tab.url?.toLowerCase().includes(urlLower));
-      if (foundIdx === -1) {
-        throw new Error(`No page matching URL "${url}"`);
-      }
-      selectedIdx = foundIdx;
-    }
-    // Priority 3: Select by title pattern
-    else if (title && typeof title === 'string') {
-      const titleLower = title.toLowerCase();
-      const foundIdx = tabs.findIndex((tab) => tab.title?.toLowerCase().includes(titleLower));
-      if (foundIdx === -1) {
-        throw new Error(`No page matching title "${title}"`);
-      }
-      selectedIdx = foundIdx;
-    } else {
-      throw new Error('Provide pageIdx, url, or title');
-    }
+  // Refresh tabs to get latest list
+  await firefox.refreshTabs();
+  const tabs = firefox.getTabs();
 
-    // Validate the selected index
-    if (!tabs[selectedIdx]) {
-      throw new Error(`Page [${selectedIdx}] not found`);
-    }
+  let selectedIdx: number;
 
-    // Select the tab
-    await firefox.selectTab(selectedIdx);
-
-    return successResponse(`selected [${selectedIdx}]`);
-  } catch (error) {
-    return errorResponse(error as Error);
+  // Priority 1: Select by index
+  if (typeof pageIdx === 'number') {
+    selectedIdx = pageIdx;
   }
-}
-
-export async function handleClosePage(args: unknown): Promise<McpToolResponse> {
-  try {
-    const { pageIdx } = args as { pageIdx: number };
-
-    if (typeof pageIdx !== 'number') {
-      throw new Error('pageIdx parameter is required and must be a number');
+  // Priority 2: Select by URL pattern
+  else if (url && typeof url === 'string') {
+    const urlLower = url.toLowerCase();
+    const foundIdx = tabs.findIndex((tab) => tab.url?.toLowerCase().includes(urlLower));
+    if (foundIdx === -1) {
+      throw new Error(`No page matching URL "${url}"`);
     }
-
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
-
-    // Refresh tabs to get latest list
-    await firefox.refreshTabs();
-    const tabs = firefox.getTabs();
-    const pageToClose = tabs[pageIdx];
-
-    if (!pageToClose) {
-      throw new Error(`Page with index ${pageIdx} not found`);
-    }
-
-    await firefox.closeTab(pageIdx);
-
-    return successResponse(`closed [${pageIdx}]`);
-  } catch (error) {
-    return errorResponse(error as Error);
+    selectedIdx = foundIdx;
   }
-}
+  // Priority 3: Select by title pattern
+  else if (title && typeof title === 'string') {
+    const titleLower = title.toLowerCase();
+    const foundIdx = tabs.findIndex((tab) => tab.title?.toLowerCase().includes(titleLower));
+    if (foundIdx === -1) {
+      throw new Error(`No page matching title "${title}"`);
+    }
+    selectedIdx = foundIdx;
+  } else {
+    throw new Error('Provide pageIdx, url, or title');
+  }
+
+  // Validate the selected index
+  if (!tabs[selectedIdx]) {
+    throw new Error(`Page [${selectedIdx}] not found`);
+  }
+
+  // Select the tab
+  await firefox.selectTab(selectedIdx);
+
+  return successResponse(`selected [${selectedIdx}]`);
+});
+
+export const handleClosePage = defineToolHandler(async function handleClosePage(
+  args: unknown
+): Promise<McpToolResponse> {
+  const { pageIdx } = args as { pageIdx: number };
+
+  if (typeof pageIdx !== 'number') {
+    throw new Error('pageIdx parameter is required and must be a number');
+  }
+
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
+
+  // Refresh tabs to get latest list
+  await firefox.refreshTabs();
+  const tabs = firefox.getTabs();
+  const pageToClose = tabs[pageIdx];
+
+  if (!pageToClose) {
+    throw new Error(`Page with index ${pageIdx} not found`);
+  }
+
+  await firefox.closeTab(pageIdx);
+
+  return successResponse(`closed [${pageIdx}]`);
+});
 
 async function respondWithContent(
   content: string,
@@ -383,20 +376,18 @@ async function respondWithContent(
   return successResponse(content.slice(0, maxLength) + '\n\n' + footer);
 }
 
-export async function handleGetPageText(args: unknown): Promise<McpToolResponse> {
-  try {
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
+export const handleGetPageText = defineToolHandler(async function handleGetPageText(
+  args: unknown
+): Promise<McpToolResponse> {
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
 
-    const text = (await firefox.evaluate(
-      'document.body ? document.body.innerText : document.documentElement.innerText'
-    )) as string | null | undefined;
+  const text = (await firefox.evaluate(
+    'document.body ? document.body.innerText : document.documentElement.innerText'
+  )) as string | null | undefined;
 
-    return respondWithContent(text ?? '', args, 'page-text', 'txt');
-  } catch (error) {
-    return errorResponse(error as Error);
-  }
-}
+  return respondWithContent(text ?? '', args, 'page-text', 'txt');
+});
 
 export const module = defineModule({
   name: 'pages',

--- a/src/tools/privileged-context.ts
+++ b/src/tools/privileged-context.ts
@@ -7,7 +7,7 @@ import { successResponse, errorResponse, previewExcerpt } from '../utils/respons
 import { validateFunction } from '../utils/js-validation.js';
 import { remoteValueToNative } from '../utils/remote-value.js';
 import { saveOutput } from '../utils/save-output.js';
-import { defineModule, type ToolDefinition } from './module.js';
+import { defineModule, defineToolHandler, type ToolDefinition } from './module.js';
 // list_extensions lives with the other extension tools in webextension.ts, but
 // it needs parent access (AddonManager), so it is registered here under the
 // privileged module rather than the unprivileged webextension module.
@@ -119,28 +119,30 @@ async function assertPrivilegedContext(firefox: any, contextId: string): Promise
   }
 }
 
-export async function handleListPrivilegedContexts(_args: unknown): Promise<McpToolResponse> {
-  try {
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
+export const handleListPrivilegedContexts = defineToolHandler(
+  async (_args: unknown): Promise<McpToolResponse> => {
+    try {
+      const { getFirefox } = await import('../index.js');
+      const firefox = await getFirefox();
 
-    const result = await firefox.sendBiDiCommand('browsingContext.getTree', {
-      'moz:scope': 'chrome',
-    });
+      const result = await firefox.sendBiDiCommand('browsingContext.getTree', {
+        'moz:scope': 'chrome',
+      });
 
-    const contexts = result.contexts || [];
+      const contexts = result.contexts || [];
 
-    return successResponse(formatContextList(contexts));
-  } catch (error) {
-    if (error instanceof Error && error.message.includes('UnsupportedOperationError')) {
-      return errorResponse(new Error(SYSTEM_ACCESS_ERROR));
+      return successResponse(formatContextList(contexts));
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('UnsupportedOperationError')) {
+        throw new Error(SYSTEM_ACCESS_ERROR);
+      }
+      throw error;
     }
-    return errorResponse(error as Error);
   }
-}
+);
 
-export async function handleSelectPrivilegedContext(args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleSelectPrivilegedContext = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     const { contextId } = args as { contextId: string };
 
     if (!contextId || typeof contextId !== 'string') {
@@ -172,18 +174,16 @@ export async function handleSelectPrivilegedContext(args: unknown): Promise<McpT
     return successResponse(
       `Switched to privileged context: ${contextId} (Marionette context set to privileged)`
     );
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+);
 
 const EvaluateResultType = {
   Exception: 'exception',
   Success: 'success',
 };
 
-export async function handleEvaluatePrivilegedScript(args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleEvaluatePrivilegedScript = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     const {
       function: fnString,
       context,
@@ -248,10 +248,8 @@ export async function handleEvaluatePrivilegedScript(args: unknown): Promise<Mcp
     } else {
       return errorResponse(`Unexpected script.callFunction result type: ${result.type}`);
     }
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+);
 
 export const module = defineModule({
   name: 'privileged',

--- a/src/tools/profiler.ts
+++ b/src/tools/profiler.ts
@@ -1,7 +1,7 @@
-import { successResponse, errorResponse } from '../utils/response-helpers.js';
+import { successResponse } from '../utils/response-helpers.js';
 import { compareVersions } from '../utils/version.js';
 import type { FirefoxDevTools } from '../firefox/index.js';
-import { defineModule, type ToolDefinition } from './module.js';
+import { defineModule, defineToolHandler, type ToolDefinition } from './module.js';
 import type { McpToolResponse } from '../types/common.js';
 
 const MIN_FIREFOX_VERSION = '154.0';
@@ -42,8 +42,8 @@ export const profilerIsActiveTool = {
   },
 } satisfies ToolDefinition;
 
-export async function handleProfilerIsActive(_args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleProfilerIsActive = defineToolHandler(
+  async (_args: unknown): Promise<McpToolResponse> => {
     const { getFirefox } = await import('../index.js');
     const firefox = await getFirefox();
     checkProfilerSupported(firefox);
@@ -51,10 +51,8 @@ export async function handleProfilerIsActive(_args: unknown): Promise<McpToolRes
     const result = await firefox.sendBiDiCommand('moz:profiler.isActive', {});
 
     return successResponse(`Profiler is ${result.active ? 'active' : 'inactive'}`);
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+);
 
 // ============================================================================
 // Tool: profiler_start
@@ -103,8 +101,8 @@ export const profilerStartTool = {
   },
 } satisfies ToolDefinition;
 
-export async function handleProfilerStart(args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleProfilerStart = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     const { preset, entries, interval, features, threads, activeContext } = args as {
       preset?: string;
       entries?: number;
@@ -146,10 +144,8 @@ export async function handleProfilerStart(args: unknown): Promise<McpToolRespons
     await firefox.sendBiDiCommand('moz:profiler.start', params);
 
     return successResponse('Profiler started');
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+);
 
 // ============================================================================
 // Tool: profiler_stop
@@ -174,8 +170,8 @@ export const profilerStopTool = {
   },
 } satisfies ToolDefinition;
 
-export async function handleProfilerStop(args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleProfilerStop = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     const { discard } = args as { discard?: boolean };
 
     const params: Record<string, unknown> = {};
@@ -193,10 +189,8 @@ export async function handleProfilerStop(args: unknown): Promise<McpToolResponse
       return successResponse(`Profile saved to: ${result.path}`);
     }
     return successResponse('Profiler stopped. No profile was saved.');
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+);
 
 export const module = defineModule({
   name: 'profiler',

--- a/src/tools/screencast.ts
+++ b/src/tools/screencast.ts
@@ -1,7 +1,7 @@
 import { successResponse, errorResponse } from '../utils/response-helpers.js';
 import { compareVersions } from '../utils/version.js';
 import type { FirefoxDevTools } from '../firefox/index.js';
-import { defineModule, type ToolDefinition } from './module.js';
+import { defineModule, defineToolHandler, type ToolDefinition } from './module.js';
 import type { McpToolResponse } from '../types/common.js';
 
 const MIN_FIREFOX_VERSION = '154.0';
@@ -62,8 +62,8 @@ export const screencastStartTool = {
   },
 } satisfies ToolDefinition;
 
-export async function handleScreencastStart(args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleScreencastStart = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     const { context, frameRate, width, height, mimeType } = (args ?? {}) as {
       context?: string;
       frameRate?: number;
@@ -108,10 +108,8 @@ export async function handleScreencastStart(args: unknown): Promise<McpToolRespo
     return successResponse(
       `Screencast started (id: ${result.screencast}). Recording to: ${result.path}`
     );
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+);
 
 // ============================================================================
 // Tool: screencast_stop
@@ -136,8 +134,8 @@ export const screencastStopTool = {
   },
 } satisfies ToolDefinition;
 
-export async function handleScreencastStop(args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleScreencastStop = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     const { screencast } = (args ?? {}) as { screencast?: string };
 
     const { getFirefox } = await import('../index.js');
@@ -170,10 +168,8 @@ export async function handleScreencastStop(args: unknown): Promise<McpToolRespon
     }
 
     return successResponse(`Screencast saved to: ${result.path}`);
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+);
 
 export const module = defineModule({
   name: 'screencast',

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -2,10 +2,10 @@
  * Screenshot tools for visual capture
  */
 
-import { successResponse, errorResponse } from '../utils/response-helpers.js';
+import { successResponse } from '../utils/response-helpers.js';
 import { handleUidError } from '../utils/uid-helpers.js';
 import { saveOutput } from '../utils/save-output.js';
-import { defineModule, type ToolDefinition } from './module.js';
+import { defineModule, defineToolHandler, type ToolDefinition } from './module.js';
 import type { McpToolResponse } from '../types/common.js';
 
 const SAVE_TO_SCHEMA = {
@@ -76,14 +76,41 @@ function imageResponse(base64Png: string): McpToolResponse {
 }
 
 // Handlers
-export async function handleScreenshotPage(args: unknown): Promise<McpToolResponse> {
+export const handleScreenshotPage = defineToolHandler(async function handleScreenshotPage(
+  args: unknown
+): Promise<McpToolResponse> {
+  const { saveTo } = (args ?? {}) as { saveTo?: boolean | string };
+
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
+
+  const base64Png = await firefox.takeScreenshotPage();
+
+  if (!base64Png || typeof base64Png !== 'string') {
+    throw new Error('Invalid screenshot data');
+  }
+
+  if (saveTo) {
+    return await saveScreenshot(base64Png, saveTo);
+  }
+
+  return imageResponse(base64Png);
+});
+
+export const handleScreenshotByUid = defineToolHandler(async function handleScreenshotByUid(
+  args: unknown
+): Promise<McpToolResponse> {
+  const { uid, saveTo } = args as { uid: string; saveTo?: boolean | string };
+
+  if (!uid || typeof uid !== 'string') {
+    throw new Error('uid required');
+  }
+
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
+
   try {
-    const { saveTo } = (args ?? {}) as { saveTo?: boolean | string };
-
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
-
-    const base64Png = await firefox.takeScreenshotPage();
+    const base64Png = await firefox.takeScreenshotByUid(uid);
 
     if (!base64Png || typeof base64Png !== 'string') {
       throw new Error('Invalid screenshot data');
@@ -95,40 +122,9 @@ export async function handleScreenshotPage(args: unknown): Promise<McpToolRespon
 
     return imageResponse(base64Png);
   } catch (error) {
-    return errorResponse(error as Error);
+    throw handleUidError(error as Error, uid);
   }
-}
-
-export async function handleScreenshotByUid(args: unknown): Promise<McpToolResponse> {
-  try {
-    const { uid, saveTo } = args as { uid: string; saveTo?: boolean | string };
-
-    if (!uid || typeof uid !== 'string') {
-      throw new Error('uid required');
-    }
-
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
-
-    try {
-      const base64Png = await firefox.takeScreenshotByUid(uid);
-
-      if (!base64Png || typeof base64Png !== 'string') {
-        throw new Error('Invalid screenshot data');
-      }
-
-      if (saveTo) {
-        return await saveScreenshot(base64Png, saveTo);
-      }
-
-      return imageResponse(base64Png);
-    } catch (error) {
-      throw handleUidError(error as Error, uid);
-    }
-  } catch (error) {
-    return errorResponse(error as Error);
-  }
-}
+});
 
 export const module = defineModule({
   name: 'screenshot',

--- a/src/tools/script.ts
+++ b/src/tools/script.ts
@@ -6,7 +6,7 @@ import { successResponse, errorResponse, previewExcerpt } from '../utils/respons
 import { remoteValueToNative } from '../utils/remote-value.js';
 import { validateFunction } from '../utils/js-validation.js';
 import { saveOutput } from '../utils/save-output.js';
-import { defineModule, type ToolDefinition } from './module.js';
+import { defineModule, defineToolHandler, type ToolDefinition } from './module.js';
 import type { McpToolResponse } from '../types/common.js';
 
 export const evaluateScriptTool = {
@@ -71,8 +71,8 @@ const EvaluateResultType = {
   Success: 'success',
 };
 
-export async function handleEvaluateScript(args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleEvaluateScript = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     const {
       function: fnString,
       args: fnArgs,
@@ -180,10 +180,8 @@ export async function handleEvaluateScript(args: unknown): Promise<McpToolRespon
     } else {
       return errorResponse(`Unexpected script.callFunction result type: ${result.type}`);
     }
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+);
 
 export const module = defineModule({
   name: 'script',

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -4,14 +4,13 @@
 
 import {
   successResponse,
-  errorResponse,
   TOKEN_LIMITS,
   previewExcerpt,
   truncationFooter,
 } from '../utils/response-helpers.js';
 import { handleUidError } from '../utils/uid-helpers.js';
 import { saveOutput } from '../utils/save-output.js';
-import { defineModule, type ToolDefinition } from './module.js';
+import { defineModule, defineToolHandler, type ToolDefinition } from './module.js';
 import type { McpToolResponse } from '../types/common.js';
 
 const DEFAULT_SNAPSHOT_LINES = 100;
@@ -97,7 +96,9 @@ export const clearSnapshotTool = {
 } satisfies ToolDefinition;
 
 // Handlers
-export async function handleTakeSnapshot(args: unknown): Promise<McpToolResponse> {
+export const handleTakeSnapshot = defineToolHandler(async function handleTakeSnapshot(
+  args: unknown
+): Promise<McpToolResponse> {
   try {
     const {
       maxLines: requestedMaxLines = DEFAULT_SNAPSHOT_LINES,
@@ -208,17 +209,15 @@ export async function handleTakeSnapshot(args: unknown): Promise<McpToolResponse
 
     return successResponse(output);
   } catch (error) {
-    return errorResponse(
-      new Error(
-        `Failed to take snapshot: ${(error as Error).message}\n\n` +
-          'The page may not be fully loaded or accessible.'
-      )
+    throw new Error(
+      `Failed to take snapshot: ${(error as Error).message}\n\n` +
+        'The page may not be fully loaded or accessible.'
     );
   }
-}
+});
 
-export async function handleResolveUidToSelector(args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleResolveUidToSelector = defineToolHandler(
+  async function handleResolveUidToSelector(args: unknown): Promise<McpToolResponse> {
     const { uid } = args as { uid: string };
 
     if (!uid || typeof uid !== 'string') {
@@ -234,23 +233,19 @@ export async function handleResolveUidToSelector(args: unknown): Promise<McpTool
     } catch (error) {
       throw handleUidError(error as Error, uid);
     }
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+);
 
-export async function handleClearSnapshot(_args: unknown): Promise<McpToolResponse> {
-  try {
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
+export const handleClearSnapshot = defineToolHandler(async function handleClearSnapshot(
+  _args: unknown
+): Promise<McpToolResponse> {
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
 
-    await firefox.clearSnapshot();
+  await firefox.clearSnapshot();
 
-    return successResponse('🧹 Snapshot cleared');
-  } catch (error) {
-    return errorResponse(error as Error);
-  }
-}
+  return successResponse('🧹 Snapshot cleared');
+});
 
 export const module = defineModule({
   name: 'snapshot',

--- a/src/tools/utilities.ts
+++ b/src/tools/utilities.ts
@@ -2,8 +2,8 @@
  * Page utility tools (dialogs, history, viewport)
  */
 
-import { successResponse, errorResponse } from '../utils/response-helpers.js';
-import { defineModule, type ToolDefinition } from './module.js';
+import { successResponse } from '../utils/response-helpers.js';
+import { defineModule, defineToolHandler, type ToolDefinition } from './module.js';
 import type { McpToolResponse } from '../types/common.js';
 
 // Tool definitions - Dialogs
@@ -80,101 +80,93 @@ export const setViewportSizeTool = {
 } satisfies ToolDefinition;
 
 // Handlers - Dialogs
-export async function handleAcceptDialog(args: unknown): Promise<McpToolResponse> {
+export const handleAcceptDialog = defineToolHandler(async function handleAcceptDialog(
+  args: unknown
+): Promise<McpToolResponse> {
+  const { promptText } = (args as { promptText?: string }) || {};
+
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
+
   try {
-    const { promptText } = (args as { promptText?: string }) || {};
-
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
-
-    try {
-      await firefox.acceptDialog(promptText);
-      return successResponse(promptText ? `Accepted: "${promptText}"` : 'Accepted');
-    } catch (error) {
-      const errorMsg = (error as Error).message;
-
-      // Concise error for no active dialog
-      if (errorMsg.includes('no such alert') || errorMsg.includes('No dialog')) {
-        throw new Error('No active dialog');
-      }
-
-      throw error;
-    }
+    await firefox.acceptDialog(promptText);
+    return successResponse(promptText ? `Accepted: "${promptText}"` : 'Accepted');
   } catch (error) {
-    return errorResponse(error as Error);
-  }
-}
+    const errorMsg = (error as Error).message;
 
-export async function handleDismissDialog(_args: unknown): Promise<McpToolResponse> {
+    // Concise error for no active dialog
+    if (errorMsg.includes('no such alert') || errorMsg.includes('No dialog')) {
+      throw new Error('No active dialog');
+    }
+
+    throw error;
+  }
+});
+
+export const handleDismissDialog = defineToolHandler(async function handleDismissDialog(
+  _args: unknown
+): Promise<McpToolResponse> {
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
+
   try {
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
-
-    try {
-      await firefox.dismissDialog();
-      return successResponse('Dismissed');
-    } catch (error) {
-      const errorMsg = (error as Error).message;
-
-      // Concise error for no active dialog
-      if (errorMsg.includes('no such alert') || errorMsg.includes('No dialog')) {
-        throw new Error('No active dialog');
-      }
-
-      throw error;
-    }
+    await firefox.dismissDialog();
+    return successResponse('Dismissed');
   } catch (error) {
-    return errorResponse(error as Error);
+    const errorMsg = (error as Error).message;
+
+    // Concise error for no active dialog
+    if (errorMsg.includes('no such alert') || errorMsg.includes('No dialog')) {
+      throw new Error('No active dialog');
+    }
+
+    throw error;
   }
-}
+});
 
 // Handlers - History
-export async function handleNavigateHistory(args: unknown): Promise<McpToolResponse> {
-  try {
-    const { direction } = args as { direction: 'back' | 'forward' };
+export const handleNavigateHistory = defineToolHandler(async function handleNavigateHistory(
+  args: unknown
+): Promise<McpToolResponse> {
+  const { direction } = args as { direction: 'back' | 'forward' };
 
-    if (!direction || (direction !== 'back' && direction !== 'forward')) {
-      throw new Error('direction parameter is required and must be "back" or "forward"');
-    }
-
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
-
-    if (direction === 'back') {
-      await firefox.navigateBack();
-    } else {
-      await firefox.navigateForward();
-    }
-
-    return successResponse(`${direction}`);
-  } catch (error) {
-    return errorResponse(error as Error);
+  if (!direction || (direction !== 'back' && direction !== 'forward')) {
+    throw new Error('direction parameter is required and must be "back" or "forward"');
   }
-}
+
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
+
+  if (direction === 'back') {
+    await firefox.navigateBack();
+  } else {
+    await firefox.navigateForward();
+  }
+
+  return successResponse(`${direction}`);
+});
 
 // Handlers - Viewport
-export async function handleSetViewportSize(args: unknown): Promise<McpToolResponse> {
-  try {
-    const { width, height } = args as { width: number; height: number };
+export const handleSetViewportSize = defineToolHandler(async function handleSetViewportSize(
+  args: unknown
+): Promise<McpToolResponse> {
+  const { width, height } = args as { width: number; height: number };
 
-    if (typeof width !== 'number' || width <= 0) {
-      throw new Error('width parameter is required and must be a positive number');
-    }
-
-    if (typeof height !== 'number' || height <= 0) {
-      throw new Error('height parameter is required and must be a positive number');
-    }
-
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
-
-    await firefox.setViewportSize(width, height);
-
-    return successResponse(`${width}x${height}`);
-  } catch (error) {
-    return errorResponse(error as Error);
+  if (typeof width !== 'number' || width <= 0) {
+    throw new Error('width parameter is required and must be a positive number');
   }
-}
+
+  if (typeof height !== 'number' || height <= 0) {
+    throw new Error('height parameter is required and must be a positive number');
+  }
+
+  const { getFirefox } = await import('../index.js');
+  const firefox = await getFirefox();
+
+  await firefox.setViewportSize(width, height);
+
+  return successResponse(`${width}x${height}`);
+});
 
 export const module = defineModule({
   name: 'utilities',

--- a/src/tools/webextension.ts
+++ b/src/tools/webextension.ts
@@ -9,8 +9,8 @@
  * Note: list_extensions requires MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1
  */
 
-import { successResponse, errorResponse } from '../utils/response-helpers.js';
-import { defineModule, type ToolDefinition } from './module.js';
+import { successResponse } from '../utils/response-helpers.js';
+import { defineModule, defineToolHandler, type ToolDefinition } from './module.js';
 import type { McpToolResponse } from '../types/common.js';
 
 // ============================================================================
@@ -51,8 +51,8 @@ export const installExtensionTool = {
   },
 } satisfies ToolDefinition;
 
-export async function handleInstallExtension(args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleInstallExtension = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     const { type, path, value, permanent } = args as {
       type: 'archivePath' | 'base64' | 'path';
       path?: string;
@@ -98,10 +98,8 @@ export async function handleInstallExtension(args: unknown): Promise<McpToolResp
     return successResponse(
       `Extension installed (${installType}):\n  ID: ${extensionId}\n  Type: ${type}${path ? `\n  Path: ${path}` : ''}`
     );
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+);
 
 // ============================================================================
 // Tool: uninstall_extension
@@ -126,8 +124,8 @@ export const uninstallExtensionTool = {
   },
 } satisfies ToolDefinition;
 
-export async function handleUninstallExtension(args: unknown): Promise<McpToolResponse> {
-  try {
+export const handleUninstallExtension = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     const { id } = args as { id: string };
 
     if (!id || typeof id !== 'string') {
@@ -140,10 +138,8 @@ export async function handleUninstallExtension(args: unknown): Promise<McpToolRe
     await firefox.sendBiDiCommand('webExtension.uninstall', { extension: id });
 
     return successResponse(`Extension uninstalled:\n  ID: ${id}`);
-  } catch (error) {
-    return errorResponse(error as Error);
   }
-}
+);
 
 // ============================================================================
 // Tool: list_extensions
@@ -229,44 +225,45 @@ function formatExtensionList(extensions: ExtensionInfo[], filterId?: string): st
   return lines.join('\n');
 }
 
-export async function handleListExtensions(args: unknown): Promise<McpToolResponse> {
-  try {
-    const { ids, name, isActive, isSystem } =
-      (args as {
-        ids?: string[];
-        name?: string;
-        isActive?: boolean;
-        isSystem?: boolean;
-      }) || {};
-
-    const { getFirefox } = await import('../index.js');
-    const firefox = await getFirefox();
-
-    // Get privileged ("chrome") contexts
-    const result = await firefox.sendBiDiCommand('browsingContext.getTree', {
-      'moz:scope': 'chrome',
-    });
-
-    const contexts = result.contexts || [];
-    if (contexts.length === 0) {
-      throw new Error(
-        'No privileged contexts available. Ensure MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 is set.'
-      );
-    }
-
-    const driver = firefox.getDriver();
-    const chromeContextId = contexts[0].context;
-    const originalContextId = firefox.getCurrentContextId();
-
+export const handleListExtensions = defineToolHandler(
+  async (args: unknown): Promise<McpToolResponse> => {
     try {
-      // Switch to chrome context
-      await driver.switchTo().window(chromeContextId);
-      await driver.setContext('chrome');
+      const { ids, name, isActive, isSystem } =
+        (args as {
+          ids?: string[];
+          name?: string;
+          isActive?: boolean;
+          isSystem?: boolean;
+        }) || {};
 
-      // Execute chrome-privileged script to get extensions
-      // Use executeAsyncScript for async operations
-      const filterParams = { ids, name, isActive, isSystem };
-      const script = `
+      const { getFirefox } = await import('../index.js');
+      const firefox = await getFirefox();
+
+      // Get privileged ("chrome") contexts
+      const result = await firefox.sendBiDiCommand('browsingContext.getTree', {
+        'moz:scope': 'chrome',
+      });
+
+      const contexts = result.contexts || [];
+      if (contexts.length === 0) {
+        throw new Error(
+          'No privileged contexts available. Ensure MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 is set.'
+        );
+      }
+
+      const driver = firefox.getDriver();
+      const chromeContextId = contexts[0].context;
+      const originalContextId = firefox.getCurrentContextId();
+
+      try {
+        // Switch to chrome context
+        await driver.switchTo().window(chromeContextId);
+        await driver.setContext('chrome');
+
+        // Execute chrome-privileged script to get extensions
+        // Use executeAsyncScript for async operations
+        const filterParams = { ids, name, isActive, isSystem };
+        const script = `
         const callback = arguments[arguments.length - 1];
         const filter = ${JSON.stringify(filterParams)};
         (async () => {
@@ -317,41 +314,40 @@ export async function handleListExtensions(args: unknown): Promise<McpToolRespon
         })();
       `;
 
-      const extensions = (await driver.executeAsyncScript(script)) as ExtensionInfo[];
+        const extensions = (await driver.executeAsyncScript(script)) as ExtensionInfo[];
 
-      // Build filter description for output
-      const filterDesc = [
-        ids && ids.length > 0 ? `ids: [${ids.join(', ')}]` : null,
-        name ? `name: "${name}"` : null,
-        typeof isActive === 'boolean' ? `active: ${isActive}` : null,
-        typeof isSystem === 'boolean' ? `system: ${isSystem}` : null,
-      ]
-        .filter(Boolean)
-        .join(', ');
+        // Build filter description for output
+        const filterDesc = [
+          ids && ids.length > 0 ? `ids: [${ids.join(', ')}]` : null,
+          name ? `name: "${name}"` : null,
+          typeof isActive === 'boolean' ? `active: ${isActive}` : null,
+          typeof isSystem === 'boolean' ? `system: ${isSystem}` : null,
+        ]
+          .filter(Boolean)
+          .join(', ');
 
-      return successResponse(formatExtensionList(extensions, filterDesc || undefined));
-    } finally {
-      // Restore previous context (skip if already on the right chrome context)
-      try {
-        if (originalContextId && originalContextId !== chromeContextId) {
-          await driver.setContext('content');
-          await driver.switchTo().window(originalContextId);
+        return successResponse(formatExtensionList(extensions, filterDesc || undefined));
+      } finally {
+        // Restore previous context (skip if already on the right chrome context)
+        try {
+          if (originalContextId && originalContextId !== chromeContextId) {
+            await driver.setContext('content');
+            await driver.switchTo().window(originalContextId);
+          }
+        } catch {
+          // Ignore errors restoring context
         }
-      } catch {
-        // Ignore errors restoring context
       }
-    }
-  } catch (error) {
-    if (error instanceof Error && error.message.includes('UnsupportedOperationError')) {
-      return errorResponse(
-        new Error(
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('UnsupportedOperationError')) {
+        throw new Error(
           'Chrome context access not enabled. Set MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1 environment variable and restart Firefox.'
-        )
-      );
+        );
+      }
+      throw error;
     }
-    return errorResponse(error as Error);
   }
-}
+);
 
 export const module = defineModule({
   name: 'webextension',

--- a/tests/tools/module.test.ts
+++ b/tests/tools/module.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import { defineToolHandler } from '../../src/tools/module.js';
+import type { McpToolResponse } from '../../src/types/common.js';
+
+describe('defineToolHandler', () => {
+  it('passes successful responses through unchanged', async () => {
+    const response: McpToolResponse = {
+      content: [{ type: 'text', text: 'ok' }],
+    };
+    const handler = defineToolHandler(async () => response);
+
+    await expect(handler()).resolves.toBe(response);
+  });
+
+  it('converts thrown errors to MCP error responses', async () => {
+    const handler = defineToolHandler(() => {
+      throw new Error('boom');
+    });
+
+    await expect(handler()).resolves.toEqual({
+      content: [{ type: 'text', text: 'Error: boom' }],
+      isError: true,
+    });
+  });
+
+  it('normalizes non-Error rejections', async () => {
+    const rejectedHandler = vi.fn<() => Promise<McpToolResponse>>().mockRejectedValue('rejected');
+    const handler = defineToolHandler(rejectedHandler);
+
+    await expect(handler()).resolves.toEqual({
+      content: [{ type: 'text', text: 'Error: rejected' }],
+      isError: true,
+    });
+  });
+});


### PR DESCRIPTION
This change moves the repeated tool handler `try/catch` logic into a shared `defineToolHandler` wrapper. Errors are still returned using the same MCP error response format.

Catches with special behavior, such as UID errors, Firefox permission errors, and context cleanup, remain inside their handlers.