### PR TITLE
fix(windows): handle file paths correctly on Windows

### DIFF
--- a/src/firefox/core.ts
+++ b/src/firefox/core.ts
@@ -15,7 +15,7 @@ import {
 } from 'node:fs';
 import { connect as netConnect } from 'node:net';
 import { homedir } from 'node:os';
-import { join, delimiter } from 'node:path';
+import { dirname, join, delimiter } from 'node:path';
 import type { FirefoxLaunchOptions } from './types.js';
 import { log, logDebug } from '../utils/logger.js';
 import { resolveProfilePath } from './profile.js';
@@ -363,6 +363,10 @@ export class FirefoxCore {
       }
 
       if (this.logFilePath) {
+        // Create the parent directory, as the generated-path branch above does.
+        // Without it a caller-supplied path whose directory is missing throws
+        // ENOENT from deep inside connect().
+        mkdirSync(dirname(this.logFilePath), { recursive: true });
         // Open file for appending, create if doesn't exist
         this.logFileFd = openSync(this.logFilePath, 'a');
         serviceBuilder.setStdio(['ignore', this.logFileFd, this.logFileFd]);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import path from 'node:path';
 
 let logStream: fs.WriteStream | null = null;
 
@@ -74,6 +75,9 @@ export function logError(message: string, error?: unknown): void {
 }
 
 export function setupLogFile(filePath: string): void {
+  // Create the parent directory first; otherwise a missing one only surfaces as
+  // a stream error and logging is silently disabled.
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
   logStream = fs.createWriteStream(filePath, { flags: 'a' });
   logStream.on('error', (error) => {
     console.error(`[firefox-devtools-mcp] Error writing to log file: ${error.message}`);

--- a/src/utils/save-output.ts
+++ b/src/utils/save-output.ts
@@ -30,6 +30,20 @@ async function isDirectory(path: string): Promise<boolean> {
 }
 
 /**
+ * Whether `candidate` is `root` or sits inside it. Compared case-insensitively
+ * on Windows, where `c:\Users\...` and `C:\Users\...` are the same directory —
+ * matching case exactly would reject valid paths, not catch escapes.
+ */
+export function isWithinRoot(root: string, candidate: string): boolean {
+  const normalize = (path: string) => (process.platform === 'win32' ? path.toLowerCase() : path);
+  const normalizedRoot = normalize(root);
+  const normalizedCandidate = normalize(candidate);
+  return (
+    normalizedCandidate === normalizedRoot || normalizedCandidate.startsWith(normalizedRoot + sep)
+  );
+}
+
+/**
  * Reject saveTo paths that escape the allowed roots, unless the server was
  * started with --unrestricted-save-paths. Relative paths must stay within the
  * current working directory; absolute paths must stay within
@@ -41,7 +55,7 @@ async function assertAllowedPath(saveTo: string, resolvedPath: string): Promise<
     return;
   }
   const root = isAbsolute(saveTo) ? homeRoot() : process.cwd();
-  if (resolvedPath !== root && !resolvedPath.startsWith(root + sep)) {
+  if (!isWithinRoot(root, resolvedPath)) {
     throw new Error(
       `saveTo "${saveTo}" resolves outside the allowed location (${resolvedPath}). Relative ` +
         `paths must stay within the current working directory and absolute paths within ` +

--- a/tests/utils/save-output.test.ts
+++ b/tests/utils/save-output.test.ts
@@ -18,7 +18,7 @@ vi.mock('node:os', async (importOriginal) => {
 const mockArgs = vi.hoisted(() => ({ unrestrictedSavePaths: false }));
 vi.mock('../../src/index.js', () => ({ args: mockArgs }));
 
-import { saveOutput } from '../../src/utils/save-output.js';
+import { saveOutput, isWithinRoot } from '../../src/utils/save-output.js';
 
 describe('saveOutput', () => {
   const tempDir = join(tmpdir(), `save-output-test-${process.pid}`);
@@ -133,5 +133,42 @@ describe('saveOutput', () => {
       expect(saved.path).toContain('snapshot-');
       expect(saved.path.endsWith('.txt')).toBe(true);
     });
+  });
+});
+
+describe('isWithinRoot', () => {
+  const originalPlatform = process.platform;
+  const root = join('C:', 'Users', 'me', '.firefox-devtools-mcp');
+
+  const setPlatform = (platform: NodeJS.Platform) =>
+    Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+
+  afterEach(() => setPlatform(originalPlatform));
+
+  it('accepts the root itself and paths inside it', () => {
+    expect(isWithinRoot(root, root)).toBe(true);
+    expect(isWithinRoot(root, join(root, 'out.json'))).toBe(true);
+    expect(isWithinRoot(root, join(root, 'nested', 'out.json'))).toBe(true);
+  });
+
+  it('rejects paths outside the root, including prefix look-alikes', () => {
+    expect(isWithinRoot(root, join('C:', 'Users', 'me', 'secrets', 'out.json'))).toBe(false);
+    expect(isWithinRoot(root, `${root}-evil`)).toBe(false);
+  });
+
+  it('ignores case on Windows, where the filesystem does too', () => {
+    setPlatform('win32');
+    expect(isWithinRoot(root, join(root.toLowerCase(), 'out.json'))).toBe(true);
+    expect(isWithinRoot(root, join(root.toUpperCase(), 'out.json'))).toBe(true);
+  });
+
+  it('still rejects an escape when case is ignored', () => {
+    setPlatform('win32');
+    expect(isWithinRoot(root, join('c:', 'users', 'me', 'secrets', 'out.json'))).toBe(false);
+  });
+
+  it('matches case exactly off Windows', () => {
+    setPlatform('linux');
+    expect(isWithinRoot(root, join(root.toLowerCase(), 'out.json'))).toBe(false);
   });
 });


### PR DESCRIPTION
Split out of #169, which @juliandescottes asked me to break into smaller pieces. This part is independent of everything else in that PR.

Two fixes around file paths:

- The `saveTo` boundary check compared the resolved path against its allowed root with a case-sensitive `startsWith`. Windows paths are case-insensitive, so `c:\Users\me\.firefox-devtools-mcp\out.json` was rejected as "outside the allowed location" while the same path with a capital drive letter was accepted. Agents produce either spelling. Ignoring case on Windows only removes false rejections, it cannot let through a path that previously escaped.

- Both log paths opened their file without ensuring the directory existed, while the auto-generated path right beside one of them already called `mkdirSync`. An `--output-file` whose directory was missing threw ENOENT from deep inside `connect()`, and a `--log-file` in the same state silently disabled logging through a stream error. Not platform-specific, just easy to hit on Windows where `/tmp/foo.log` does not exist at all.

Verified on Windows 11, Node 22.22.0, Firefox 154.0. Every case was reproduced against `main` first:

| case | `main` | this branch |
| --- | --- | --- |
| `saveTo` with a lowercase drive letter (`c:\Users\...`) | rejected | accepted |
| `saveTo` with an uppercased segment (`\USERS\`) | rejected | accepted |
| `--log-file` into a missing directory | logging silently disabled | directory created, lines written |
| `--output-file` into a missing directory | ENOENT out of `connect()` | Firefox starts, 374 KB captured |

The escapes still fail closed: a path outside the root, the `~/.firefox-devtools-mcp-evil` prefix look-alike, a `..` traversal, and the same traversal spelled with a lowercase drive letter are all still rejected. Unit suite, typecheck, lint and `format:check` are green on Windows.
