### PR TITLE
chore: make dev tooling cross-platform

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -30,7 +30,7 @@ tasks:
   clean:
     desc: Clean build artifacts
     cmds:
-      - node -e "for (const p of ['dist', 'node_modules', 'package-lock.json']) require('node:fs').rmSync(p, { recursive: true, force: true })"
+      - node -e "for (const p of ['dist', 'node_modules', 'package-lock.json']) require('node:fs').rmSync(p, {recursive:true, force:true})"
 
   typecheck:
     desc: Run TypeScript type checking
@@ -89,7 +89,7 @@ tasks:
       - npm run inspector:dev
 
   bump-version:
-    desc: Bump version in package.json and plugin.json (usage: task bump-version -- 0.9.8)
+    desc: 'Bump version in package.json and plugin.json (usage: task bump-version -- 0.9.8)'
     cmds:
       - node scripts/bump-version.mjs {{.CLI_ARGS}}
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -30,9 +30,7 @@ tasks:
   clean:
     desc: Clean build artifacts
     cmds:
-      - rm -rf dist
-      - rm -rf node_modules
-      - rm -f package-lock.json
+      - node -e "for (const p of ['dist', 'node_modules', 'package-lock.json']) require('node:fs').rmSync(p, { recursive: true, force: true })"
 
   typecheck:
     desc: Run TypeScript type checking

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "publish:moz": "node scripts/publish-moz-package.mjs",
     "start": "node dist/index.js",
     "setup": "node scripts/setup-mcp-config.js",
-    "clean": "rm -rf dist",
+    "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
     "typecheck": "tsc",
     "typecheck:tests": "tsc -p tests/tsconfig.json",
     "lint": "eslint src tests --ext .ts",

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -5,7 +5,7 @@
  * manifest.json, then runs `mcpb pack` on it.
  */
 
-import { readFileSync, writeFileSync, existsSync, cpSync, mkdtempSync, rmSync } from 'node:fs';
+import { readFileSync, writeFileSync, cpSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -35,9 +35,7 @@ try {
   );
 
   const outDir = resolve(root, 'dist-mcpb');
-  if (!existsSync(outDir)) {
-    execSync(`mkdir -p ${outDir}`);
-  }
+  mkdirSync(outDir, { recursive: true });
   const outFile = resolve(outDir, `firefox-devtools-mcp-${pkg.version}.mcpb`);
 
   console.log('Packing .mcpb bundle...');

--- a/scripts/test-mozlog.js
+++ b/scripts/test-mozlog.js
@@ -2,11 +2,13 @@
 
 import { FirefoxDevTools } from '../dist/index.js';
 import { readFileSync, existsSync } from 'fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 async function test() {
   console.log('=== Test: MOZ_LOG and Script Injection (headless) ===\n');
 
-  const logFile = '/tmp/firefox-mozlog-test.log';
+  const logFile = join(tmpdir(), 'firefox-mozlog-test.log');
 
   const firefox = new FirefoxDevTools({
     headless: true,


### PR DESCRIPTION
Split out of #169, which @juliandescottes asked me to break into smaller pieces. Dev tooling only, no `src/` changes.

- `npm run clean` shelled out to `rm -rf`, which does not exist in the cmd.exe that npm runs scripts through. That also broke `prepublishOnly`, so `npm publish` could not run on Windows at all.
- `npm run build:mcpb` shelled out to `mkdir -p` for the same reason. cmd.exe does not fail on that one outright: its `mkdir` reads `-p` as a second directory name, so the build quietly leaves a stray `-p` directory in the repo root, and a later run with `-p` present and `dist-mcpb` gone exits 1 and takes `execSync` down with it.
- `npm run test:mozlog` hardcoded `/tmp/firefox-mozlog-test.log`, which resolves to `C:\tmp` on Windows and does not exist, so the script died with ENOENT before launching Firefox. It now uses the platform temp directory, as the sibling scripts already do.
- The Taskfile's `clean` task shelled out to `rm -rf`.

Two things I changed relative to #169: the `.gitattributes` part is gone, since #164 already landed it, and I kept the `test:integration:win` entry, because the runner it points at is only removed by the integration-suite commit that stays in #169.

The last commit is a YAML fix rather than a portability one, and it is worth a word. A plain YAML scalar cannot contain a colon followed by a space, and the replacement `clean` command has two of them inside `{ recursive: true, force: true }`, so `task` refused to parse the file and reported `mapping values are not allowed in this context`. Dropping the spaces after those colons fixes it. While confirming that, I found the same problem already on `main`, in the `bump-version` description:

```yaml
desc: Bump version in package.json and plugin.json (usage: task bump-version -- 0.9.8)
```

`task` cannot parse the Taskfile today because of that line, so `clean` would have stayed unreachable even after this PR. I quoted it here. Happy to split that one line out if you would rather keep this PR to portability alone.

Verified on Windows 11, Node 22.22.0. `npm run clean`, `npm run build:mcpb` and `npm publish --dry-run` (which runs `prepublishOnly`) all fail on `main` and pass here. `npm run test:mozlog` runs end to end and captures its log under `%TEMP%`. `task --list` now parses the whole file, and `task clean` removes `dist`, `node_modules` and `package-lock.json` as intended.
