### PR TITLE
fix(windows): auto-detect Firefox binary for per-user installs

### DIFF
--- a/src/firefox/core.ts
+++ b/src/firefox/core.ts
@@ -18,6 +18,7 @@ import { homedir } from 'node:os';
 import { dirname, join, delimiter } from 'node:path';
 import type { FirefoxLaunchOptions } from './types.js';
 import { log, logDebug } from '../utils/logger.js';
+import { findFirefoxBinaryWindows } from './windows-binary.js';
 import { resolveProfilePath } from './profile.js';
 
 // ---------------------------------------------------------------------------
@@ -150,8 +151,14 @@ async function findGeckodriver(): Promise<string> {
   return found;
 }
 
+/** geckodriver's "unable to find binary" error never mentions the fix. */
+const BINARY_NOT_FOUND_HINT =
+  'Unable to detect Firefox binary automatically, please provide the full path via ' +
+  '--firefox-path';
+
 export class FirefoxCore {
   private currentContextId: string | null = null;
+  private detectedBinaryPath: string | undefined;
   private driver: WebDriver | null = null;
   private firefoxVersion: string | null = null;
   private logFileFd: number | undefined;
@@ -319,6 +326,14 @@ export class FirefoxCore {
       }
       if (this.options.firefoxPath) {
         firefoxOptions.setBinary(this.options.firefoxPath);
+      } else if (process.platform === 'win32') {
+        // geckodriver misses per-user Windows installs.
+        const discoveredBinary = findFirefoxBinaryWindows();
+        if (discoveredBinary) {
+          logDebug(`Using auto-detected Firefox binary: ${discoveredBinary}`);
+          firefoxOptions.setBinary(discoveredBinary);
+          this.detectedBinaryPath = discoveredBinary;
+        }
       }
       if (this.options.args && this.options.args.length > 0) {
         firefoxOptions.addArguments(...this.options.args);
@@ -371,11 +386,20 @@ export class FirefoxCore {
         serviceBuilder.addArguments('--log', remoteLogLevel.toLowerCase());
       }
 
-      this.driver = await new Builder()
-        .forBrowser(Browser.FIREFOX)
-        .setFirefoxOptions(firefoxOptions)
-        .setFirefoxService(serviceBuilder)
-        .build();
+      try {
+        this.driver = await new Builder()
+          .forBrowser(Browser.FIREFOX)
+          .setFirefoxOptions(firefoxOptions)
+          .setFirefoxService(serviceBuilder)
+          .build();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        // geckodriver names the capability it wanted when it found no binary.
+        if (message.includes('moz:firefoxOptions.binary')) {
+          throw new Error(`${BINARY_NOT_FOUND_HINT}\n\nOriginal error: ${message}`);
+        }
+        throw error;
+      }
     }
 
     log(
@@ -508,6 +532,11 @@ export class FirefoxCore {
    */
   getOptions(): FirefoxLaunchOptions {
     return this.options;
+  }
+
+  /** Binary auto-detected at launch, when the caller supplied no --firefox-path. */
+  getDetectedBinaryPath(): string | undefined {
+    return this.detectedBinaryPath;
   }
 
   /**

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -592,6 +592,11 @@ export class FirefoxClient {
     return this.core.getOptions();
   }
 
+  /** Binary auto-detected at launch, when the caller supplied no --firefox-path. */
+  getDetectedBinaryPath(): string | undefined {
+    return this.core.getDetectedBinaryPath();
+  }
+
   // ============================================================================
   // Cleanup
   // ============================================================================

--- a/src/firefox/windows-binary.ts
+++ b/src/firefox/windows-binary.ts
@@ -1,0 +1,122 @@
+/**
+ * Firefox binary discovery.
+ *
+ * On Windows geckodriver only searches the Program Files directories and
+ * HKEY_LOCAL_MACHINE, so it cannot see a per-user install (%LOCALAPPDATA%,
+ * registered under HKCU) — what the installer produces without admin rights.
+ * Finding the binary here and passing it as moz:firefoxOptions.binary fixes
+ * that. Only used on Windows: geckodriver's own lookup suffices elsewhere.
+ *
+ * The lookup belongs in geckodriver itself, tracked as
+ * https://bugzilla.mozilla.org/show_bug.cgi?id=1921933; this can go once that
+ * ships.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, statSync } from 'node:fs';
+import { win32 as windowsPath } from 'node:path';
+import { logDebug } from '../utils/logger.js';
+
+/** Install directory name plus executable, relative to a candidate root. */
+const WINDOWS_RELATIVE_PATH = windowsPath.join('Mozilla Firefox', 'firefox.exe');
+
+/**
+ * Probed in geckodriver's own order — Program Files before the per-user
+ * location — so setups that already work keep resolving to the same binary.
+ */
+const WINDOWS_ROOT_ENV_VARS = ['ProgramFiles', 'ProgramW6432', 'ProgramFiles(x86)', 'LOCALAPPDATA'];
+
+/** Registry values holding the path to firefox.exe; HKCU is the per-user install. */
+const WINDOWS_REGISTRY_KEYS = [
+  'HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\firefox.exe',
+  'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\firefox.exe',
+];
+
+/**
+ * Extracts the value from `reg query ... /ve` output. Splits on the `REG_SZ`
+ * type tag because the value name is localised on non-English Windows.
+ */
+export function parseRegQueryOutput(output: string): string | null {
+  for (const line of output.split(/\r?\n/)) {
+    const match = /\bREG_(?:SZ|EXPAND_SZ)\b\s+(.+)$/.exec(line);
+    if (match?.[1]) {
+      const value = match[1].trim();
+      if (value) {
+        return value;
+      }
+    }
+  }
+  return null;
+}
+
+function isExecutableFile(path: string): boolean {
+  try {
+    return existsSync(path) && statSync(path).isFile();
+  } catch {
+    return false; // Unreadable candidate — treat as absent.
+  }
+}
+
+/**
+ * Absolute path to reg.exe. Resolving it by name would go through PATH, and an
+ * MCP client can launch the server with a minimal environment — the registry is
+ * the last resort, so it must not depend on PATH being populated.
+ */
+function regExecutable(): string {
+  const systemRoot = process.env.SystemRoot ?? process.env.windir;
+  return systemRoot ? windowsPath.join(systemRoot, 'System32', 'reg.exe') : 'reg';
+}
+
+function queryWindowsRegistry(key: string): string | null {
+  try {
+    const output = execFileSync(regExecutable(), ['query', key, '/ve'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
+    });
+    return parseRegQueryOutput(output);
+  } catch {
+    return null; // Missing key, or reg.exe unavailable.
+  }
+}
+
+/**
+ * Locates firefox.exe when the caller did not supply a binary. Returns null
+ * when nothing was found.
+ */
+export function findFirefoxBinaryWindows(): string | null {
+  for (const envVar of WINDOWS_ROOT_ENV_VARS) {
+    const root = process.env[envVar];
+    if (!root) {
+      continue;
+    }
+    const candidate = windowsPath.join(root, WINDOWS_RELATIVE_PATH);
+    if (isExecutableFile(candidate)) {
+      logDebug(`Found Firefox via %${envVar}%: ${candidate}`);
+      return candidate;
+    }
+  }
+
+  // A PATH-exposed firefox.exe is deliberate (and how CI images pin a build).
+  for (const dir of (process.env.PATH ?? '').split(windowsPath.delimiter)) {
+    if (!dir) {
+      continue;
+    }
+    const candidate = windowsPath.join(dir, 'firefox.exe');
+    if (isExecutableFile(candidate)) {
+      logDebug(`Found Firefox on PATH: ${candidate}`);
+      return candidate;
+    }
+  }
+
+  // Last resort: ask Windows, which also covers relocated installs.
+  for (const key of WINDOWS_REGISTRY_KEYS) {
+    const value = queryWindowsRegistry(key);
+    if (value && isExecutableFile(value)) {
+      logDebug(`Found Firefox via registry ${key}: ${value}`);
+      return value;
+    }
+  }
+
+  return null;
+}

--- a/src/tools/firefox-management.ts
+++ b/src/tools/firefox-management.ts
@@ -130,7 +130,11 @@ export const handleGetFirefoxInfo = defineToolHandler(async (_input: unknown) =>
   info.push('Firefox Instance Configuration');
   info.push('');
 
-  info.push(`Binary: ${options.firefoxPath ?? 'System Firefox (default)'}`);
+  const detectedBinary = firefox.getDetectedBinaryPath();
+  const binaryLabel =
+    options.firefoxPath ??
+    (detectedBinary ? `${detectedBinary} (auto-detected)` : 'System Firefox (default)');
+  info.push(`Binary: ${binaryLabel}`);
   info.push(`Firefox version: ${version ?? '(unknown)'}`);
   info.push(`Headless: ${options.headless ? 'Yes' : 'No'}`);
 

--- a/tests/firefox/core.test.ts
+++ b/tests/firefox/core.test.ts
@@ -403,3 +403,77 @@ describe('FirefoxCore connect() profile handling', () => {
     expect(String(geckodriverPath)).toContain('geckodriver');
   });
 });
+
+describe('FirefoxCore connect() binary lookup failure', () => {
+  // Verbatim geckodriver wording; the capability name is the stable part.
+  const geckodriverMessage =
+    'Expected browser binary location, but unable to find binary in default location, ' +
+    "no 'moz:firefoxOptions.binary' capability provided, and no binary flag set on the command line";
+
+  function mockFailingBuild(message: string): void {
+    vi.doMock('selenium-webdriver/firefox.js', () => ({
+      default: {
+        Options: class {
+          enableBidi = vi.fn();
+          addArguments = vi.fn();
+          setBinary = vi.fn();
+          windowSize = vi.fn();
+          setAcceptInsecureCerts = vi.fn();
+        },
+        ServiceBuilder: class {
+          setStdio = vi.fn();
+          addArguments = vi.fn();
+        },
+      },
+    }));
+
+    vi.doMock('selenium-webdriver', () => ({
+      Builder: class {
+        forBrowser = vi.fn().mockReturnThis();
+        setFirefoxOptions = vi.fn().mockReturnThis();
+        setFirefoxService = vi.fn().mockReturnThis();
+        build = vi.fn().mockRejectedValue(new Error(message));
+      },
+      Browser: { FIREFOX: 'firefox' },
+    }));
+
+    vi.doMock('node:fs', () => ({
+      existsSync: vi.fn((p: unknown) => String(p).includes('geckodriver')),
+      mkdirSync: vi.fn(),
+      copyFileSync: vi.fn(),
+      openSync: vi.fn().mockReturnValue(3),
+      closeSync: vi.fn(),
+    }));
+
+    vi.doMock('@/firefox/windows-binary.js', () => ({
+      findFirefoxBinaryWindows: vi.fn(() => null),
+    }));
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('points at --firefox-path when geckodriver found no binary', async () => {
+    mockFailingBuild(geckodriverMessage);
+    const { FirefoxCore } = await import('@/firefox/core.js');
+
+    const core = new FirefoxCore({ headless: true });
+
+    await expect(core.connect()).rejects.toThrow(
+      /--firefox-path[\s\S]*Original error: Expected browser binary location/
+    );
+  });
+
+  it('passes other launch failures through unchanged', async () => {
+    const original = 'Process unexpectedly closed with status 1';
+    mockFailingBuild(original);
+    const { FirefoxCore } = await import('@/firefox/core.js');
+
+    const core = new FirefoxCore({ headless: true });
+
+    await expect(core.connect()).rejects.toThrow(original);
+    await expect(core.connect()).rejects.not.toThrow('--firefox-path');
+  });
+});

--- a/tests/firefox/windows-binary.test.ts
+++ b/tests/firefox/windows-binary.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { win32 as windowsPath } from 'node:path';
+
+import { findFirefoxBinaryWindows, parseRegQueryOutput } from '@/firefox/windows-binary.js';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, existsSync: vi.fn(), statSync: vi.fn() };
+});
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return { ...actual, execFileSync: vi.fn() };
+});
+
+const { existsSync, statSync } = await import('node:fs');
+const { execFileSync } = await import('node:child_process');
+
+const mockExists = vi.mocked(existsSync);
+const mockStat = vi.mocked(statSync);
+const mockExec = vi.mocked(execFileSync);
+
+/** Pretend only the listed paths exist as regular files. */
+function presentFiles(...paths: string[]): void {
+  const present = new Set(paths);
+  mockExists.mockImplementation((p) => present.has(String(p)));
+  mockStat.mockImplementation(
+    (p) => ({ isFile: () => present.has(String(p)) }) as ReturnType<typeof statSync>
+  );
+}
+
+describe('parseRegQueryOutput', () => {
+  it('extracts the default value from reg query output', () => {
+    const output = [
+      '',
+      'HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\firefox.exe',
+      '    (Default)    REG_SZ    C:\\Users\\me\\AppData\\Local\\Mozilla Firefox\\firefox.exe',
+      '',
+    ].join('\r\n');
+
+    expect(parseRegQueryOutput(output)).toBe(
+      'C:\\Users\\me\\AppData\\Local\\Mozilla Firefox\\firefox.exe'
+    );
+  });
+
+  it('handles a localised value name, since only the type tag is stable', () => {
+    const output = '    (Standard)    REG_SZ    C:\\Firefox\\firefox.exe';
+    expect(parseRegQueryOutput(output)).toBe('C:\\Firefox\\firefox.exe');
+  });
+
+  it('accepts REG_EXPAND_SZ values', () => {
+    const output = '    (Default)    REG_EXPAND_SZ    C:\\Firefox\\firefox.exe';
+    expect(parseRegQueryOutput(output)).toBe('C:\\Firefox\\firefox.exe');
+  });
+
+  it('returns null when the key holds no value', () => {
+    expect(parseRegQueryOutput('ERROR: The system was unable to find the key.')).toBeNull();
+  });
+});
+
+describe('findFirefoxBinaryWindows', () => {
+  const env = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...env };
+    delete process.env.ProgramFiles;
+    delete process.env.ProgramW6432;
+    delete process.env['ProgramFiles(x86)'];
+    delete process.env.LOCALAPPDATA;
+    // Set explicitly: the real process.env is case-insensitive on Windows (the
+    // key is SYSTEMROOT), but the plain object above is not.
+    process.env.SystemRoot = 'C:\\Windows';
+    process.env.PATH = '';
+    mockExec.mockImplementation(() => {
+      throw new Error('key not found');
+    });
+    presentFiles();
+  });
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  it('finds a machine-wide install under Program Files', () => {
+    process.env.ProgramFiles = 'C:\\Program Files';
+    const expected = windowsPath.join('C:\\Program Files', 'Mozilla Firefox', 'firefox.exe');
+    presentFiles(expected);
+
+    expect(findFirefoxBinaryWindows()).toBe(expected);
+  });
+
+  it('finds a per-user install under LOCALAPPDATA — the case geckodriver misses', () => {
+    process.env.LOCALAPPDATA = 'C:\\Users\\me\\AppData\\Local';
+    const expected = windowsPath.join(
+      'C:\\Users\\me\\AppData\\Local',
+      'Mozilla Firefox',
+      'firefox.exe'
+    );
+    presentFiles(expected);
+
+    expect(findFirefoxBinaryWindows()).toBe(expected);
+  });
+
+  it('prefers Program Files over LOCALAPPDATA so working setups keep their binary', () => {
+    process.env.ProgramFiles = 'C:\\Program Files';
+    process.env.LOCALAPPDATA = 'C:\\Users\\me\\AppData\\Local';
+    const programFiles = windowsPath.join('C:\\Program Files', 'Mozilla Firefox', 'firefox.exe');
+    presentFiles(
+      programFiles,
+      windowsPath.join('C:\\Users\\me\\AppData\\Local', 'Mozilla Firefox', 'firefox.exe')
+    );
+
+    expect(findFirefoxBinaryWindows()).toBe(programFiles);
+  });
+
+  it('falls back to firefox.exe on PATH', () => {
+    process.env.PATH = ['C:\\nowhere', 'C:\\tools\\firefox'].join(';');
+    const expected = windowsPath.join('C:\\tools\\firefox', 'firefox.exe');
+    presentFiles(expected);
+
+    expect(findFirefoxBinaryWindows()).toBe(expected);
+  });
+
+  it('falls back to the registry when nothing is in a predictable location', () => {
+    const registryPath = 'D:\\Custom\\Firefox\\firefox.exe';
+    presentFiles(registryPath);
+    mockExec.mockReturnValue(`    (Default)    REG_SZ    ${registryPath}\r\n` as never);
+
+    expect(findFirefoxBinaryWindows()).toBe(registryPath);
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.stringContaining('reg.exe'),
+      expect.arrayContaining(['query', expect.stringContaining('HKCU'), '/ve']),
+      expect.anything()
+    );
+  });
+
+  it('invokes reg.exe by absolute path, so an empty PATH cannot break the fallback', () => {
+    process.env.SystemRoot = 'C:\\Windows';
+    const registryPath = 'D:\\Custom\\Firefox\\firefox.exe';
+    presentFiles(registryPath);
+    mockExec.mockReturnValue(`    (Default)    REG_SZ    ${registryPath}\r\n` as never);
+
+    expect(findFirefoxBinaryWindows()).toBe(registryPath);
+    expect(mockExec).toHaveBeenCalledWith(
+      windowsPath.join('C:\\Windows', 'System32', 'reg.exe'),
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('ignores a registry path that no longer exists on disk', () => {
+    presentFiles();
+    mockExec.mockReturnValue('    (Default)    REG_SZ    D:\\Gone\\firefox.exe\r\n' as never);
+
+    expect(findFirefoxBinaryWindows()).toBeNull();
+  });
+
+  it('returns null when Firefox is nowhere to be found', () => {
+    expect(findFirefoxBinaryWindows()).toBeNull();
+  });
+});

--- a/tests/tools/firefox-management.test.ts
+++ b/tests/tools/firefox-management.test.ts
@@ -222,6 +222,7 @@ describe('Firefox Management Tools', () => {
           },
         }),
         getLogFilePath: vi.fn().mockReturnValue(undefined),
+        getDetectedBinaryPath: vi.fn().mockReturnValue(undefined),
         getFirefoxVersion: vi.fn().mockReturnValue('123.4'),
       };
 
@@ -245,6 +246,7 @@ describe('Firefox Management Tools', () => {
           headless: true,
         }),
         getLogFilePath: vi.fn().mockReturnValue(undefined),
+        getDetectedBinaryPath: vi.fn().mockReturnValue(undefined),
       };
 
       mockGetFirefox.mockResolvedValue(mockFirefoxNoPrefs);
@@ -255,6 +257,37 @@ describe('Firefox Management Tools', () => {
 
       const text = result.content[0].text;
       expect(text).not.toContain('Preferences:');
+    });
+
+    it('should report an auto-detected binary path', async () => {
+      const detected = 'C:\\Users\\me\\AppData\\Local\\Mozilla Firefox\\firefox.exe';
+      mockGetFirefox.mockResolvedValue({
+        getOptions: vi.fn().mockReturnValue({ headless: true }),
+        getFirefoxVersion: vi.fn().mockReturnValue('154.0'),
+        getLogFilePath: vi.fn().mockReturnValue(undefined),
+        getDetectedBinaryPath: vi.fn().mockReturnValue(detected),
+      });
+
+      const { handleGetFirefoxInfo } = await import('../../src/tools/firefox-management.js');
+
+      const result = await handleGetFirefoxInfo({});
+
+      expect(result.content[0].text).toContain(`Binary: ${detected} (auto-detected)`);
+    });
+
+    it('should fall back to the default label when no binary was detected', async () => {
+      mockGetFirefox.mockResolvedValue({
+        getOptions: vi.fn().mockReturnValue({ headless: true }),
+        getFirefoxVersion: vi.fn().mockReturnValue('154.0'),
+        getLogFilePath: vi.fn().mockReturnValue(undefined),
+        getDetectedBinaryPath: vi.fn().mockReturnValue(undefined),
+      });
+
+      const { handleGetFirefoxInfo } = await import('../../src/tools/firefox-management.js');
+
+      const result = await handleGetFirefoxInfo({});
+
+      expect(result.content[0].text).toContain('Binary: System Firefox (default)');
     });
   });
 });


### PR DESCRIPTION
Split out of #169, which @juliandescottes asked me to break into smaller pieces. This is the part that needs a decision rather than just a review.

geckodriver only searches the Program Files directories and HKEY_LOCAL_MACHINE for Firefox, so it cannot see an install made without administrator rights: that one lands in `%LOCALAPPDATA%\Mozilla Firefox` and registers under HKCU. Launching then fails with "Expected browser binary location, but unable to find binary in default location" even though Firefox is installed and working.

You pointed at https://bugzilla.mozilla.org/show_bug.cgi?id=1921933 and you are right that this belongs in geckodriver. I am happy to take that mentored bug. The open question is whether you want an interim workaround in the MCP in the meantime, or would rather wait for the upstream fix and close this. I have referenced the bug in the module header either way, so it is clear this is meant to go away.

Changes from the review on #169:

- shortened the not-found message to your wording and moved the constant into `core.ts`, its only caller
- renamed `binaryLookupFailed` to `windowsBinaryLookupFailed`
- the module and its test now use `path.win32` instead of the ambient `path`. That was the failing check on #169: the suite mocks `process.platform` but ran on a Linux runner, so PATH was split on `:` instead of `;` and the lookup returned null.

Verified on Windows 11, Node 22.22.0, against a real per-user Firefox 154.0: nothing in either Program Files directory, nothing under HKLM, only `%LOCALAPPDATA%\Mozilla Firefox` and the HKCU registration. On `main` that machine fails with the "unable to find binary in default location" message above. On this branch:

- Firefox launches in 1.1 s and `get_firefox_info` reports `Binary: C:\Users\...\AppData\Local\Mozilla Firefox\firefox.exe (auto-detected)`
- the full server over stdio works end to end: 32 tools listed, `navigate_page` and `evaluate_script` both fine
- lookup order holds: with a Program Files install present it wins over the per-user one, matching geckodriver
- the fallbacks work in order, PATH then HKCU, and the registry lookup still resolves with an empty PATH, which is what invoking `reg.exe` by absolute path is for
- with nothing findable, the error names `--firefox-path` and keeps the original geckodriver message
- an explicit `--firefox-path` skips detection entirely

One gap worth knowing about: a PATH entry wrapped in quotes (`"C:\some dir";...`) is not unquoted before probing, so that entry is skipped. It falls through to the registry rather than failing, and I left it alone since this module is meant to be short-lived, but say the word and I will strip them.
