### PR TITLE
chore: ignore typescript config files in eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -52,6 +52,10 @@
   },
   "overrides": [
     {
+      "files": ["*.config.ts", "*.config.*.ts"],
+      "extends": ["plugin:@typescript-eslint/disable-type-checked"]
+    },
+    {
       "files": ["tests/**/*.ts"],
       "parserOptions": {
         "project": "./tests/tsconfig.json"


### PR DESCRIPTION
Ignoring vitest config in eslint to avoid parsing errors with the ESlint extension.

<img width="856" height="218" alt="image" src="https://github.com/user-attachments/assets/8ef3f361-4cc4-43bf-b965-c731ee532426" />
