### PR TITLE
chore: remove deprecated vitest poolOptions configurations

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,11 +11,6 @@ export default defineConfig({
     // Run tests sequentially to avoid Firefox port conflicts
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],


### PR DESCRIPTION
Vitest 4 rewrote its pool system and removed `poolOptions` entirely. The repo upgraded to **Vitest 4.1.8** but its config wasn't fully migrated.

Causing this warning to show up when `npm run test:unit` is ran:
<img width="1465" height="56" alt="image" src="https://github.com/user-attachments/assets/579d6782-da2f-4696-bd24-11346e933228" />


This change removes the deprecated vitest configurations from `vitest.config.ts`.