### PR TITLE
fix: correct tsup config types

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,19 +1,19 @@
 import { readFileSync } from 'fs';
-import { defineConfig } from 'tsup';
+import { defineConfig, type Options } from 'tsup';
 
 const { name, version } = JSON.parse(readFileSync('./package.json', 'utf8'));
 
 export const nodeConfig = {
   entry: { index: 'src/index.public.ts' },
   outDir: 'dist',
-  format: ['esm'] as const,
-  target: 'node20' as const,
+  format: ['esm'],
+  target: 'node20',
   bundle: true,
   minify: false,
   sourcemap: false,
   clean: true,
   dts: false,
-  platform: 'node' as const,
+  platform: 'node',
   splitting: false,
   external: ['selenium-webdriver'],
   noExternal: ['@modelcontextprotocol/sdk', 'zod', 'dotenv'],
@@ -21,21 +21,21 @@ export const nodeConfig = {
     __SERVER_NAME__: JSON.stringify(name),
     __SERVER_VERSION__: JSON.stringify(version),
   },
-};
+} satisfies Options;
 
 export const browserConfig = {
   entry: { 'snapshot.injected': 'src/firefox/snapshot/injected/snapshot.injected.ts' },
   outDir: 'dist',
-  format: ['iife'] as const,
-  target: 'es2020' as const,
+  format: ['iife'],
+  target: 'es2020',
   bundle: true,
   minify: true,
   sourcemap: false,
   clean: false,
   dts: false,
-  platform: 'browser' as const,
+  platform: 'browser',
   globalName: '__SnapshotInjected',
   onSuccess: 'echo "Build completed successfully!"',
-};
+} satisfies Options;
 
 export default defineConfig([nodeConfig, browserConfig]);


### PR DESCRIPTION
Fixing TypeScript errors in the tsup configuration caused by using `as const` on config values such as `format`.

<img width="813" height="166" alt="image" src="https://github.com/user-attachments/assets/3d8d19a9-ca19-45d5-b74b-07b2c8e8d631" />

The config objects now use `satisfies Options`, which keeps type inference while making sure the config uses valid tsup types.