### PR TITLE
feat: disconnect idle existing Firefox sessions

### DIFF
--- a/src/firefox/idle-connection.ts
+++ b/src/firefox/idle-connection.ts
@@ -1,0 +1,80 @@
+export const EXISTING_FIREFOX_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+
+interface ExistingFirefoxIdleControllerOptions {
+  enabled: boolean;
+  hasActiveConnection: () => boolean;
+  disconnect: () => Promise<void>;
+  onDisconnectError: (error: unknown) => void;
+  timeoutMs?: number;
+}
+
+export class ExistingFirefoxIdleController {
+  private activeCalls = 0;
+  private timer: NodeJS.Timeout | undefined;
+  private disconnecting: Promise<void> | undefined;
+  private disposed = false;
+  private readonly timeoutMs: number;
+
+  constructor(private readonly options: ExistingFirefoxIdleControllerOptions) {
+    this.timeoutMs = options.timeoutMs ?? EXISTING_FIREFOX_IDLE_TIMEOUT_MS;
+  }
+
+  async runWithActivity<T>(operation: () => Promise<T>): Promise<T> {
+    this.clearTimer();
+    if (this.disconnecting) {
+      await this.disconnecting;
+    }
+
+    this.activeCalls++;
+    try {
+      return await operation();
+    } finally {
+      this.activeCalls--;
+      this.armTimer();
+    }
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true;
+    this.clearTimer();
+    await this.disconnecting;
+  }
+
+  private armTimer(): void {
+    this.clearTimer();
+    if (
+      this.disposed ||
+      !this.options.enabled ||
+      this.activeCalls > 0 ||
+      !this.options.hasActiveConnection()
+    ) {
+      return;
+    }
+
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      if (this.disposed || this.activeCalls > 0 || !this.options.hasActiveConnection()) {
+        return;
+      }
+      this.disconnecting = this.disconnectIdle();
+    }, this.timeoutMs);
+    this.timer.unref();
+  }
+
+  private clearTimer(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  private async disconnectIdle(): Promise<void> {
+    try {
+      await this.options.disconnect();
+    } catch (error) {
+      this.options.onDisconnectError(error);
+    } finally {
+      this.disconnecting = undefined;
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { parsePrefs, defaultProfileDir } from './cli.js';
 import type { parseArguments } from './cli.js';
 import { FirefoxDevTools } from './firefox/index.js';
 import type { FirefoxLaunchOptions } from './firefox/types.js';
+import { ExistingFirefoxIdleController } from './firefox/idle-connection.js';
 import { buildToolset } from './tools/registry.js';
 import { errorResponse } from './utils/response-helpers.js';
 
@@ -65,6 +66,10 @@ export function setNextLaunchOptions(options: FirefoxLaunchOptions): void {
  */
 export function isFirefoxRunning(): boolean {
   return firefox !== null;
+}
+
+function hasActiveExistingFirefoxConnection(): boolean {
+  return firefox?.getOptions().connectExisting === true;
 }
 
 /**
@@ -179,6 +184,13 @@ export async function run(
 
   args = parseArgsFn(SERVER_VERSION);
 
+  const idleConnection = new ExistingFirefoxIdleController({
+    enabled: Boolean(args.connectExisting),
+    hasActiveConnection: hasActiveExistingFirefoxConnection,
+    disconnect: resetFirefox,
+    onDisconnectError: (error) => logError('Error disconnecting idle Firefox session', error),
+  });
+
   if (args.logFile) {
     setupLogFile(args.logFile);
   }
@@ -247,25 +259,27 @@ export async function run(
       throw new Error(`Unknown tool: ${name}`);
     }
 
-    try {
-      const result = await handler(args);
-      if (pendingWarning) {
-        // Return as isError so that agents acting as MCP clients (e.g. Claude)
-        // surface the message to the user.
-        // Also note the operation completed so the agent does not retry.
-        const operationNote =
-          result.content[0]?.type === 'text'
-            ? `\n\n[Note: The operation also completed — ${result.content[0].text}]`
-            : '';
-        const warning = pendingWarning;
-        pendingWarning = null;
-        return errorResponse(`${warning}${operationNote}`);
+    return idleConnection.runWithActivity(async () => {
+      try {
+        const result = await handler(args);
+        if (pendingWarning) {
+          // Return as isError so that agents acting as MCP clients (e.g. Claude)
+          // surface the message to the user.
+          // Also note the operation completed so the agent does not retry.
+          const operationNote =
+            result.content[0]?.type === 'text'
+              ? `\n\n[Note: The operation also completed — ${result.content[0].text}]`
+              : '';
+          const warning = pendingWarning;
+          pendingWarning = null;
+          return errorResponse(`${warning}${operationNote}`);
+        }
+        return result;
+      } catch (error) {
+        logError(`Error executing tool ${name}`, error);
+        throw error;
       }
-      return result;
-    } catch (error) {
-      logError(`Error executing tool ${name}`, error);
-      throw error;
-    }
+    });
   });
 
   const transport = new StdioServerTransport();
@@ -277,6 +291,7 @@ export async function run(
   // Clean up the Marionette session so Firefox accepts new connections.
   // Without this, the session stays locked after the MCP client disconnects.
   const cleanup = async () => {
+    await idleConnection.dispose();
     await resetFirefox();
     await server.close();
     await flushLogs().catch(() => {});

--- a/tests/firefox/idle-connection.test.ts
+++ b/tests/firefox/idle-connection.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  EXISTING_FIREFOX_IDLE_TIMEOUT_MS,
+  ExistingFirefoxIdleController,
+} from '@/firefox/idle-connection.js';
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('ExistingFirefoxIdleController', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('disconnects an existing Firefox connection after 30 minutes idle', async () => {
+    let connected = true;
+    const disconnect = vi.fn(async () => {
+      connected = false;
+    });
+    const controller = new ExistingFirefoxIdleController({
+      enabled: true,
+      hasActiveConnection: () => connected,
+      disconnect,
+      onDisconnectError: vi.fn(),
+    });
+
+    await controller.runWithActivity(async () => undefined);
+    await vi.advanceTimersByTimeAsync(EXISTING_FIREFOX_IDLE_TIMEOUT_MS - 1);
+    expect(disconnect).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(connected).toBe(false);
+  });
+
+  it('does not schedule idle disconnects for MCP-launched Firefox', async () => {
+    const disconnect = vi.fn(async () => undefined);
+    const controller = new ExistingFirefoxIdleController({
+      enabled: false,
+      hasActiveConnection: () => true,
+      disconnect,
+      onDisconnectError: vi.fn(),
+    });
+
+    await controller.runWithActivity(async () => undefined);
+    await vi.advanceTimersByTimeAsync(EXISTING_FIREFOX_IDLE_TIMEOUT_MS * 2);
+
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('resets the timeout when another tool call starts', async () => {
+    const disconnect = vi.fn(async () => undefined);
+    const controller = new ExistingFirefoxIdleController({
+      enabled: true,
+      hasActiveConnection: () => true,
+      disconnect,
+      onDisconnectError: vi.fn(),
+    });
+
+    await controller.runWithActivity(async () => undefined);
+    await vi.advanceTimersByTimeAsync(EXISTING_FIREFOX_IDLE_TIMEOUT_MS / 2);
+    await controller.runWithActivity(async () => undefined);
+    await vi.advanceTimersByTimeAsync(EXISTING_FIREFOX_IDLE_TIMEOUT_MS / 2);
+    expect(disconnect).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(EXISTING_FIREFOX_IDLE_TIMEOUT_MS / 2);
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+
+  it('does not disconnect while a long-running tool call is active', async () => {
+    const operation = deferred();
+    const disconnect = vi.fn(async () => undefined);
+    const controller = new ExistingFirefoxIdleController({
+      enabled: true,
+      hasActiveConnection: () => true,
+      disconnect,
+      onDisconnectError: vi.fn(),
+    });
+
+    const running = controller.runWithActivity(() => operation.promise);
+    await vi.advanceTimersByTimeAsync(EXISTING_FIREFOX_IDLE_TIMEOUT_MS * 2);
+    expect(disconnect).not.toHaveBeenCalled();
+
+    operation.resolve();
+    await running;
+    await vi.advanceTimersByTimeAsync(EXISTING_FIREFOX_IDLE_TIMEOUT_MS);
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+
+  it('waits for all concurrent tool calls before starting the timeout', async () => {
+    const first = deferred();
+    const second = deferred();
+    const disconnect = vi.fn(async () => undefined);
+    const controller = new ExistingFirefoxIdleController({
+      enabled: true,
+      hasActiveConnection: () => true,
+      disconnect,
+      onDisconnectError: vi.fn(),
+    });
+
+    const firstRun = controller.runWithActivity(() => first.promise);
+    const secondRun = controller.runWithActivity(() => second.promise);
+    first.resolve();
+    await firstRun;
+    await vi.advanceTimersByTimeAsync(EXISTING_FIREFOX_IDLE_TIMEOUT_MS * 2);
+    expect(disconnect).not.toHaveBeenCalled();
+
+    second.resolve();
+    await secondRun;
+    await vi.advanceTimersByTimeAsync(EXISTING_FIREFOX_IDLE_TIMEOUT_MS);
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the server alive and reconnects lazily across repeated idle cycles', async () => {
+    let connected = false;
+    const disconnect = vi.fn(async () => {
+      connected = false;
+    });
+    const controller = new ExistingFirefoxIdleController({
+      enabled: true,
+      hasActiveConnection: () => connected,
+      disconnect,
+      onDisconnectError: vi.fn(),
+    });
+    let connectionCount = 0;
+    const useFirefox = () =>
+      controller.runWithActivity(async () => {
+        if (!connected) {
+          connected = true;
+          connectionCount++;
+        }
+      });
+
+    await useFirefox();
+    await vi.advanceTimersByTimeAsync(EXISTING_FIREFOX_IDLE_TIMEOUT_MS);
+    expect(connected).toBe(false);
+    expect(disconnect).toHaveBeenCalledOnce();
+
+    await useFirefox();
+    expect(connectionCount).toBe(2);
+    expect(disconnect).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(EXISTING_FIREFOX_IDLE_TIMEOUT_MS);
+    await useFirefox();
+    expect(connectionCount).toBe(3);
+  });
+
+  it('does nothing when the timeout fires without an active connection', async () => {
+    let connected = true;
+    const disconnect = vi.fn(async () => undefined);
+    const controller = new ExistingFirefoxIdleController({
+      enabled: true,
+      hasActiveConnection: () => connected,
+      disconnect,
+      onDisconnectError: vi.fn(),
+    });
+
+    await controller.runWithActivity(async () => undefined);
+    connected = false;
+    await vi.advanceTimersByTimeAsync(EXISTING_FIREFOX_IDLE_TIMEOUT_MS);
+
+    expect(disconnect).not.toHaveBeenCalled();
+  });
+
+  it('clears its timer during cleanup', async () => {
+    const disconnect = vi.fn(async () => undefined);
+    const controller = new ExistingFirefoxIdleController({
+      enabled: true,
+      hasActiveConnection: () => true,
+      disconnect,
+      onDisconnectError: vi.fn(),
+    });
+
+    await controller.runWithActivity(async () => undefined);
+    expect(vi.getTimerCount()).toBe(1);
+
+    await controller.dispose();
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(EXISTING_FIREFOX_IDLE_TIMEOUT_MS);
+    expect(disconnect).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Bugzilla: [Bug 2066912](https://bugzilla.mozilla.org/show_bug.cgi?id=2066912)

This change disconnects from an existing Firefox instance after 30 minutes of inactivity when using `--connect-existing`. The Firefox process itself stays open, and the MCP reconnects to the same instance on the next tool call. The idle timeout is reset by new tool activity and does not run while a tool call is still in progress.

I tested it manually by:
1. connecting to an existing Firefox and running a tool via inspector
2. waiting for the idle timeout and confirming geckodriver exits while Firefox stays open (you can refer to background processes for this)
3. calling another tool and confirming the MCP reconnects to the Firefox instance (it should reconnect to that same instance, but that specifically is not confirmed yet)