### PR TITLE
chore: add setup to trigger integration tests on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   push:
     branches: [main, develop]
+  # Pull requests only run the full matrix when opted in with the
+  # run-integration label, which requires write access to apply.
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -10,6 +14,11 @@ concurrency:
 
 jobs:
   test:
+    # Gate the job rather than the trigger: a skipped job still reports a
+    # conclusion, so the check never stays pending on unlabeled pull requests.
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'run-integration')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -54,14 +63,18 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage reports to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == 20
+        if: >-
+          github.event_name != 'pull_request' && matrix.os == 'ubuntu-latest' &&
+          matrix.node-version == 20
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
       - name: Upload artifacts
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == 20
+        if: >-
+          github.event_name != 'pull_request' && matrix.os == 'ubuntu-latest' &&
+          matrix.node-version == 20
         uses: actions/upload-artifact@v7
         with:
           name: dist

--- a/docs/ci-and-release.md
+++ b/docs/ci-and-release.md
@@ -4,7 +4,9 @@ This project ships with ready-to-use GitHub Actions for CI, release, and npm pub
 
 Workflows
 - CI (.github/workflows/ci.yml)
-  - Triggers on push (main, develop) and PRs.
+  - Triggers on push (main, develop).
+  - On pull requests, only runs when the `run-integration` label is applied. It is the
+    only workflow that runs the integration suite, so it is opt-in per PR.
   - Matrix: Node 20 and 22.
   - Steps: install → lint → format check → typecheck → test → build.
   - Optional: uploads coverage to Codecov if `coverage/lcov.info` exists and `CODECOV_TOKEN` is set.


### PR DESCRIPTION
At the moment it's a bit painful to investigate intermittents, because integration tests only run on main.
With this, you can label a PR with `run-integration` and it should trigger the integration tests.