### PR TITLE
fix: bypass Selenium Manager only where it cannot run

### DIFF
--- a/src/firefox/core.ts
+++ b/src/firefox/core.ts
@@ -364,11 +364,30 @@ export class FirefoxCore {
         }
       }
 
-      // Always resolve geckodriver ourselves rather than relying on selenium
-      // entirely. See Bug 2062055, 2040849.
-      const geckodriverPath = await findGeckodriver();
-      logDebug(`Using geckodriver: ${geckodriverPath}`);
-      const serviceBuilder = new firefox.ServiceBuilder(geckodriverPath);
+      // Resolve geckodriver ourselves only where Selenium Manager cannot do the
+      // job, because giving the service an executable costs more than it looks.
+      // selenium-webdriver calls getBinaryPaths() only when the DriverService
+      // has none, and that single call resolves geckodriver *and* the Firefox
+      // binary it injects into moz:firefoxOptions.binary. Passing a path
+      // therefore also opts out of finding Firefox, which is exactly what the
+      // Android branch above relies on and what broke desktop users with no
+      // system Firefox in 0.10.2.
+      //   win32: ServiceBuilder() invoked from the MCP hangs (Bug 2040849).
+      //   non-x64 Linux: Selenium Manager ships an x86-64 binary that cannot
+      //   execute on aarch64 (Bug 2062055).
+      // Everywhere else Selenium Manager works, so let it resolve both.
+      const mustResolveGeckodriver =
+        process.platform === 'win32' || (process.platform === 'linux' && process.arch !== 'x64');
+
+      let serviceBuilder;
+      if (mustResolveGeckodriver) {
+        const geckodriverPath = await findGeckodriver();
+        logDebug(`Using geckodriver: ${geckodriverPath}`);
+        serviceBuilder = new firefox.ServiceBuilder(geckodriverPath);
+      } else {
+        logDebug('Letting Selenium Manager resolve geckodriver and Firefox');
+        serviceBuilder = new firefox.ServiceBuilder();
+      }
 
       if (this.logFilePath) {
         // Create the parent directory, as the generated-path branch above does.

--- a/src/firefox/core.ts
+++ b/src/firefox/core.ts
@@ -364,18 +364,10 @@ export class FirefoxCore {
         }
       }
 
-      // Resolve geckodriver ourselves only where Selenium Manager cannot do the
-      // job, because giving the service an executable costs more than it looks.
-      // selenium-webdriver calls getBinaryPaths() only when the DriverService
-      // has none, and that single call resolves geckodriver *and* the Firefox
-      // binary it injects into moz:firefoxOptions.binary. Passing a path
-      // therefore also opts out of finding Firefox, which is exactly what the
-      // Android branch above relies on and what broke desktop users with no
-      // system Firefox in 0.10.2.
-      //   win32: ServiceBuilder() invoked from the MCP hangs (Bug 2040849).
-      //   non-x64 Linux: Selenium Manager ships an x86-64 binary that cannot
-      //   execute on aarch64 (Bug 2062055).
-      // Everywhere else Selenium Manager works, so let it resolve both.
+      // Giving the service an executable skips getBinaryPaths(), which resolves
+      // geckodriver *and* the Firefox binary injected into moz:firefoxOptions.binary.
+      // Only do that where Selenium Manager cannot run: win32 hangs when invoked from
+      // the MCP (Bug 2040849), non-x64 Linux ships an x86-64 binary (Bug 2062055).
       const mustResolveGeckodriver =
         process.platform === 'win32' || (process.platform === 'linux' && process.arch !== 'x64');
 

--- a/tests/firefox/core.test.ts
+++ b/tests/firefox/core.test.ts
@@ -4,7 +4,7 @@
 
 import { join } from 'node:path';
 import { MCP_PROFILE_DIR_NAME } from '@/firefox/profile.js';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { FirefoxCore } from '@/firefox/core.js';
 import type { FirefoxLaunchOptions } from '@/firefox/types.js';
 
@@ -389,18 +389,55 @@ describe('FirefoxCore connect() profile handling', () => {
     );
   });
 
-  // Bug 2062055: geckodriver path should always be resolved before calling
-  // the ServiceBuilder.
-  it('should build the geckodriver service with an explicit binary path', async () => {
-    const { FirefoxCore } = await import('@/firefox/core.js');
+  // Bug 2062055 and its follow-up. Giving the DriverService an executable also
+  // opts out of Selenium Manager resolving the Firefox binary, so the explicit
+  // path is only correct where Selenium Manager cannot run.
+  describe('geckodriver resolution', () => {
+    const platform = process.platform;
+    const arch = process.arch;
 
-    const core = new FirefoxCore({ headless: true });
-    await core.connect();
+    const setPlatform = (value: NodeJS.Platform, archValue: string) => {
+      Object.defineProperty(process, 'platform', { value, configurable: true });
+      Object.defineProperty(process, 'arch', { value: archValue, configurable: true });
+    };
 
-    expect(mockServiceBuilderCtor).toHaveBeenCalledTimes(1);
-    const [geckodriverPath] = mockServiceBuilderCtor.mock.calls[0] as [unknown];
-    expect(typeof geckodriverPath).toBe('string');
-    expect(String(geckodriverPath)).toContain('geckodriver');
+    afterEach(() => {
+      setPlatform(platform, arch);
+    });
+
+    it.each([
+      ['win32', 'x64'],
+      ['linux', 'arm64'],
+    ] as const)(
+      'resolves geckodriver explicitly on %s/%s, where Selenium Manager cannot',
+      async (osName, archName) => {
+        setPlatform(osName, archName);
+        const { FirefoxCore } = await import('@/firefox/core.js');
+
+        await new FirefoxCore({ headless: true }).connect();
+
+        expect(mockServiceBuilderCtor).toHaveBeenCalledTimes(1);
+        const [geckodriverPath] = mockServiceBuilderCtor.mock.calls[0] as [unknown];
+        expect(typeof geckodriverPath).toBe('string');
+        expect(String(geckodriverPath)).toContain('geckodriver');
+      }
+    );
+
+    it.each([
+      ['linux', 'x64'],
+      ['darwin', 'arm64'],
+    ] as const)(
+      'leaves the service executable unset on %s/%s, so Selenium Manager still finds Firefox',
+      async (osName, archName) => {
+        setPlatform(osName, archName);
+        const { FirefoxCore } = await import('@/firefox/core.js');
+
+        await new FirefoxCore({ headless: true }).connect();
+
+        expect(mockServiceBuilderCtor).toHaveBeenCalledTimes(1);
+        expect(mockServiceBuilderCtor.mock.calls[0]).toHaveLength(0);
+      }
+    );
   });
 });
 


### PR DESCRIPTION
Fixes the browser-resolution regression in 0.10.2 reported by @mightykatun on #170. Their diagnosis was correct and this is essentially the fix they proposed.

## What broke

#170 (mine) made every platform pass an explicit geckodriver path to `firefox.ServiceBuilder`. That fixed aarch64 Linux, where Selenium Manager ships an x86-64 binary that cannot execute, but it regressed everyone else.

`selenium-webdriver`'s Firefox `Driver.createSession()` calls `getBinaryPaths(caps)` **only when the supplied `DriverService` has no executable**. That one call resolves geckodriver *and* the Firefox binary, which it then injects into `moz:firefoxOptions.binary`. Handing the service a path therefore also opts out of finding Firefox.

On a machine with no system Firefox and none on `PATH`:

- **0.10.1**: Selenium Manager downloads and selects a Firefox under `~/.cache/selenium/firefox/`, and `list_pages` succeeds with no `--firefox-path`.
- **0.10.2**: first tool call fails with `Unable to detect Firefox binary automatically, please provide the full path via --firefox-path`.

This is the same mechanism the Android branch in `connect()` relies on deliberately, where skipping `getBinaryPaths()` is what stops a desktop binary being injected over `androidPackage`. The comment there describes the behaviour exactly. I changed the desktop path without noticing it applied there too.

## The fix

Bypass Selenium Manager only where it genuinely cannot do the job:

- `win32`, where `ServiceBuilder()` invoked from the MCP hangs (Bug 2040849)
- non-x64 Linux, where the Selenium Manager binary cannot execute (Bug 2062055)

Everywhere else the executable is left unset, so Selenium Manager resolves both halves as it did in 0.10.1.

## On the test

The unit test I added in #170 asserted an explicit service executable on *every* platform. It encoded the regression as the expected behaviour, so it could never have caught this, and it passed happily while users broke. It is replaced with per-platform cases covering both sides.

I verified these actually fail against the shipped code rather than just passing against mine: reverting `core.ts` to the 0.10.2 logic fails the two "leaves the service executable unset" cases and passes the rest.

```
× leaves the service executable unset on linux/x64, so Selenium Manager still finds Firefox
× leaves the service executable unset on darwin/arm64, so Selenium Manager still finds Firefox
  Tests  2 failed | 26 passed (28)
```

With this change: 686 unit tests pass, lint, prettier and both typecheck configs clean.

## Not covered here

The longer-term options @mightykatun raised, an architecture-compatible Selenium Manager binary or our own browser resolver, would let all platforms share one path. This is the minimal restoration of 0.10.1 behaviour for affected users; happy to follow up on either.

Sorry for the breakage, and thanks to @mightykatun for a report that arrived with the root cause already in it.
